### PR TITLE
Fixed fold_user reflection comparison

### DIFF
--- a/gotype/fold_user.go
+++ b/gotype/fold_user.go
@@ -32,7 +32,7 @@ func makeUserFoldFn(fn reflect.Value) (userFoldFn, error) {
 	}
 
 	ta1 := t.In(1)
-	if ta1 != tExtVisitor {
+	if ta1.Name() != tExtVisitor.Name() {
 		return nil, fmt.Errorf("second arument in function '%v' must be structform.ExtVisitor", t.Name())
 	}
 


### PR DESCRIPTION
Hey.

I recently came upon a problem when using this with Elastic Beats. The comparison on line 35 in `gotype/fold_user.go` came out false even though the two are of the same type.

The following fix properly checks this.