### PR TITLE
Add support to disable html escaping in json encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Add SetEscapeHTML to json visitor. (PR #4)
 
 ### Changed
 

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -86,6 +86,16 @@ func TestStringEncoding(t *testing.T) {
 			htmlEscape: false,
 			expected:   `"<hello>world</hello>"`,
 		},
+		"html with double quotes": testCase{
+			in:         `<hello id="hola">`,
+			htmlEscape: true,
+			expected:   `"\u003chello id=\"hola\"\u003e"`,
+		},
+		"html with single quotes": testCase{
+			in:         `<hello id='hola'>`,
+			htmlEscape: true,
+			expected:   `"\u003chello id='hola'\u003e"`,
+		},
 	}
 
 	for name, test := range cases {

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	structform "github.com/elastic/go-structform"
 	"github.com/elastic/go-structform/sftest"
 )
@@ -50,4 +52,53 @@ func testEncParseConsistent(
 				return parse(buf.Bytes(), to)
 			}
 		})
+}
+
+func TestStringEncoding(t *testing.T) {
+	type testCase struct {
+		in         string
+		htmlEscape bool
+		expected   string
+	}
+
+	cases := map[string]testCase{
+		"no escaping required": testCase{
+			in:       "hello world",
+			expected: `"hello world"`,
+		},
+		"json required escaping": testCase{
+			in:         `"hello \nworld"`,
+			htmlEscape: false,
+			expected:   `"\"hello \\nworld\""`,
+		},
+		"html escape with json required escaping": testCase{
+			in:         `"hello \nworld"`,
+			htmlEscape: true,
+			expected:   `"\"hello \\nworld\""`,
+		},
+		"html with html escaping enabled": testCase{
+			in:         "<hello>world</hello>",
+			htmlEscape: true,
+			expected:   `"\u003chello\u003eworld\u003c/hello\u003e"`,
+		},
+		"html without html escaping": testCase{
+			in:         "<hello>world</hello>",
+			htmlEscape: false,
+			expected:   `"<hello>world</hello>"`,
+		},
+	}
+
+	for name, test := range cases {
+		in, htmlEscape, expected := test.in, test.htmlEscape, test.expected
+
+		t.Run(name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			visitor := NewVisitor(buf)
+			visitor.SetEscapeHTML(htmlEscape)
+			visitor.OnString(in)
+
+			actual := buf.String()
+			assert.Equal(t, expected, actual)
+		})
+	}
 }


### PR DESCRIPTION
- Introduce escapeSet for faster lookup
- Introduce json only and json+html escape set
- Add SetEscapeHTML to json Visitor

Running encoder benchmarks on beats events, the throughput is slightly improved on my machine (tests have been run with `-count 4`:

```
benchmark                                                   old ns/op     new ns/op     delta
BenchmarkEncodeBeatsEvents/packetbeat/structform-json-4     5761339       5517418       -4.23%
BenchmarkEncodeBeatsEvents/packetbeat/structform-json-4     5760408       5525191       -4.08%
BenchmarkEncodeBeatsEvents/packetbeat/structform-json-4     5851125       5596085       -4.36%
BenchmarkEncodeBeatsEvents/packetbeat/structform-json-4     5866086       5505591       -6.15%
BenchmarkEncodeBeatsEvents/metricbeat/structform-json-4     2157219       2063404       -4.35%
BenchmarkEncodeBeatsEvents/metricbeat/structform-json-4     2135076       2089063       -2.16%
BenchmarkEncodeBeatsEvents/metricbeat/structform-json-4     2147042       2074319       -3.39%
BenchmarkEncodeBeatsEvents/metricbeat/structform-json-4     2137110       2071244       -3.08%
BenchmarkEncodeBeatsEvents/filebeat/structform-json-4       30558740      28957667      -5.24%
BenchmarkEncodeBeatsEvents/filebeat/structform-json-4       30593264      29055035      -5.03%
BenchmarkEncodeBeatsEvents/filebeat/structform-json-4       30588813      30026662      -1.84%
BenchmarkEncodeBeatsEvents/filebeat/structform-json-4       30555227      29109094      -4.73%

benchmark                                                   old MB/s     new MB/s     speedup
BenchmarkEncodeBeatsEvents/packetbeat/structform-json-4     118.41       123.64       1.04x
BenchmarkEncodeBeatsEvents/packetbeat/structform-json-4     118.42       123.47       1.04x
BenchmarkEncodeBeatsEvents/packetbeat/structform-json-4     116.59       121.90       1.05x
BenchmarkEncodeBeatsEvents/packetbeat/structform-json-4     116.29       123.91       1.07x
BenchmarkEncodeBeatsEvents/metricbeat/structform-json-4     95.95        100.32       1.05x
BenchmarkEncodeBeatsEvents/metricbeat/structform-json-4     96.95        99.08        1.02x
BenchmarkEncodeBeatsEvents/metricbeat/structform-json-4     96.41        99.79        1.04x
BenchmarkEncodeBeatsEvents/metricbeat/structform-json-4     96.86        99.94        1.03x
BenchmarkEncodeBeatsEvents/filebeat/structform-json-4       161.74       170.68       1.06x
BenchmarkEncodeBeatsEvents/filebeat/structform-json-4       161.56       170.11       1.05x
BenchmarkEncodeBeatsEvents/filebeat/structform-json-4       161.58       164.60       1.02x
BenchmarkEncodeBeatsEvents/filebeat/structform-json-4       161.76       169.79       1.05x
```