### PR TITLE
Add support to Reset the unfolder

### DIFF
--- a/gotype/unfold.go
+++ b/gotype/unfold.go
@@ -129,6 +129,11 @@ func (u *Unfolder) EnableKeyCache(max int) {
 	u.keyCache.init(max)
 }
 
+// Reset reinitializes the unfolder and removes all references to the target
+// object. Use Reset if the unfolder is re-used and the target changed.
+// References to the target can prevent the garbage collector from collecting
+// the target after processing. Use Reset to set the target to `nil`.
+// SetTarget must be called after Reset and before another Unfold operation.
 func (u *Unfolder) Reset() {
 	u.SetTarget(nil)
 }

--- a/gotype/unfold.go
+++ b/gotype/unfold.go
@@ -110,12 +110,7 @@ func NewUnfolder(to interface{}) (*Unfolder, error) {
 	u.key.init()
 	u.idx.init()
 	u.baseType.init()
-
-	u.valueBuffer = unfoldBuf{
-		arrays:       make([][]byte, 0, 4),
-		mapPrimitive: make([]map[string]byte, 0, 1),
-		mapAny:       make([]map[string]interface{}, 0, 4),
-	}
+	u.valueBuffer.init()
 
 	// TODO: make allocation buffer size configurable
 	// u.buf.init(1024)
@@ -134,8 +129,25 @@ func (u *Unfolder) EnableKeyCache(max int) {
 	u.keyCache.init(max)
 }
 
+func (u *Unfolder) Reset() {
+	u.SetTarget(nil)
+}
+
 func (u *Unfolder) SetTarget(to interface{}) error {
 	ctx := &u.unfoldCtx
+
+	if to == nil {
+		// reset internal states on nil
+		u.unfolder.init(&unfolderNoTarget{})
+		u.value.init(reflect.Value{})
+		u.ptr.init()
+		u.key.init()
+		u.idx.init()
+		u.baseType.init()
+		u.valueBuffer.reset()
+
+		return nil
+	}
 
 	if ptr, u := lookupGoTypeUnfolder(to); u != nil {
 		u.initState(ctx, ptr)
@@ -287,4 +299,22 @@ func (r *typeUnfoldRegistry) set(t reflect.Type, f reflUnfolder) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.m[t] = f
+}
+
+func makeUnfoldBuf() unfoldBuf {
+	return unfoldBuf{
+		arrays:       make([][]byte, 0, 4),
+		mapPrimitive: make([]map[string]byte, 0, 1),
+		mapAny:       make([]map[string]interface{}, 0, 4),
+	}
+}
+
+func (u *unfoldBuf) init() {
+	*u = makeUnfoldBuf()
+}
+
+func (u *unfoldBuf) reset() {
+	u.arrays = u.arrays[:0]
+	u.mapPrimitive = u.mapPrimitive[:0]
+	u.mapAny = u.mapAny[:0]
 }

--- a/gotype/unfold_test.go
+++ b/gotype/unfold_test.go
@@ -325,6 +325,9 @@ func TestUnfoldJsonInto(t *testing.T) {
 			t.Error(err)
 			continue
 		}
+
+		// clear unfolder state.
+		un.Reset()
 	}
 }
 
@@ -354,7 +357,6 @@ func BenchmarkUnfoldJsonInto(b *testing.B) {
 				if err != nil {
 					b.Error(err)
 				}
-
 			}
 		})
 	}


### PR DESCRIPTION
The unfolder keeps references into into original target, set via
SetTarget, potentially creating memory leaks in applications re-using the
unfolder. If the folder, or unfolding failed, then the unfolder is in
an invalid state and can not be reused.

By introducing Reset and adding support for SetTarget(nil),
go-structform:
- allows the re-use of Unfolder after an error
- remove references to the target object, so the object can be gc'ed