### PR TITLE
Modernize tests

### DIFF
--- a/gotype/fold_test.go
+++ b/gotype/fold_test.go
@@ -21,254 +21,42 @@ import (
 	"bytes"
 	gojson "encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	structform "github.com/elastic/go-structform"
 	"github.com/elastic/go-structform/json"
 	"github.com/elastic/go-structform/sftest"
-	"github.com/stretchr/testify/assert"
 )
 
-var foldSamples = []struct {
+type foldCase struct {
 	json  string
 	value interface{}
-}{
-	// primitives
-	{`null`, nil},
-	{`true`, true},
-	{`false`, false},
-	{`10`, int8(10)},
-	{`10`, int32(10)},
-	{`10`, int(10)},
-	{`10`, uint(10)},
-	{`10`, uint8(10)},
-	{`10`, uint16(10)},
-	{`10`, uint32(10)},
-	{`12340`, uint16(12340)},
-	{`1234567`, uint32(1234567)},
-	{`12345678190`, uint64(12345678190)},
-	{`-10`, int8(-10)},
-	{`-10`, int32(-10)},
-	{`-10`, int(-10)},
-	{`3.14`, float32(3.14)},
-	{`3.14`, float64(3.14)},
-	{`"test"`, "test"},
-	{`"test with \" being escaped"`, "test with \" being escaped"},
-
-	// arrays
-	{`[]`, []uint8{}},
-	{`[]`, []string{}},
-	{`[]`, []interface{}{}},
-	{`[]`, []struct{ A string }{}},
-	{`[[]]`, [][]uint8{{}}},
-	{`[[]]`, [][]string{{}}},
-	{`[[]]`, [][]interface{}{{}}},
-	{`[[]]`, [][]struct{ A string }{{}}},
-	{
-		`[null,true,false,12345678910,3.14,"test"]`,
-		[]interface{}{nil, true, false, uint64(12345678910), 3.14, "test"},
-	},
-	{`[1,2,3,4,5,6,7,8,9,10]`, []int8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
-	{`[1,2,3,4,5,6,7,8,9,10]`, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
-	{`[1,2,3,4,5,6,7,8,9,10]`, []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
-	{`[1,2,3,4,5,6,7,8,9,10]`, []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
-	{`[1,2,3,4,5,6,7,8,9,10]`, []interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
-	{`["testa","testb","testc"]`, []string{"testa", "testb", "testc"}},
-	{`["testa","testb","testc"]`, []interface{}{"testa", "testb", "testc"}},
-
-	// objects
-	{`{}`, map[string]interface{}{}},
-	{`{}`, map[string]int8{}},
-	{`{}`, map[string]int64{}},
-	{`{}`, map[string]struct{ A *int }{}},
-	{`{}`, mapstr{}},
-	{`{"a":null}`, map[string]interface{}{"a": nil}},
-	{`{"a":null}`, mapstr{"a": nil}},
-	{`{"a":null}`, struct{ A *int }{}},
-	{`{"a":null}`, struct{ A *struct{ B int } }{}},
-	{`{"a":true,"b":1,"c":"test"}`, map[string]interface{}{"a": true, "b": 1, "c": "test"}},
-	{`{"a":true,"b":1,"c":"test"}`, mapstr{"a": true, "b": 1, "c": "test"}},
-	{`{"a":true,"b":1,"c":"test"}`, struct {
-		A bool
-		B int
-		C string
-	}{true, 1, "test"}},
-
-	{`{"field":[1,2,3,4,5,6,7,8,9,10]}`,
-		map[string]interface{}{
-			"field": []int8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		},
-	},
-	{`{"field":[1,2,3,4,5,6,7,8,9,10]}`,
-		map[string]interface{}{
-			"field": []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		},
-	},
-	{`{"field":[1,2,3,4,5,6,7,8,9,10]}`,
-		mapstr{
-			"field": []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		},
-	},
-	{`{"field":[1,2,3,4,5,6,7,8,9,10]}`,
-		map[string][]int{
-			"field": []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		},
-	},
-	{`{"field":[1,2,3,4,5,6,7,8,9,10]}`,
-		struct {
-			Field []int
-		}{
-			Field: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		},
-	},
-
-	// structs with inlines
-	{
-		`{"a": 1}`,
-		struct {
-			X interface{} `struct:",inline"`
-		}{X: map[string]int{"a": 1}},
-	},
-	{
-		`{"a": 1}`,
-		struct {
-			X interface{} `struct:",inline"`
-		}{X: struct{ A int }{1}},
-	},
-	{
-		`{"a": 1}`,
-		struct {
-			X interface{} `struct:",inline"`
-		}{X: &struct{ A int }{1}},
-	},
-	{
-		`{"a": 1}`,
-		struct {
-			X map[string]interface{} `struct:",inline"`
-		}{X: map[string]interface{}{"a": 1}},
-	},
-	{
-		`{"a": 1}`,
-		struct {
-			X map[string]int `struct:",inline"`
-		}{X: map[string]int{"a": 1}},
-	},
-	{
-		`{"a": 1}`,
-		struct {
-			X struct{ A int } `struct:",inline"`
-		}{X: struct{ A int }{1}},
-	},
-
-	// omit empty without values
-	{
-		`{"a": 1}`,
-		struct {
-			A int
-			B interface{} `struct:",omitempty"`
-		}{A: 1},
-	},
-	{
-		`{"a": 1}`,
-		struct {
-			A int
-			B map[string]interface{} `struct:",omitempty"`
-		}{A: 1},
-	},
-	{
-		`{"a": 1}`,
-		struct {
-			A int
-			B []int `struct:",omitempty"`
-		}{A: 1},
-	},
-	{
-		`{"a": 1}`,
-		struct {
-			A int
-			B string `struct:",omitempty"`
-		}{A: 1},
-	},
-	{
-		`{"a": 1}`,
-		struct {
-			A int
-			B *int `struct:",omitempty"`
-		}{A: 1},
-	},
-	{
-		`{"a": 1}`,
-		struct {
-			A int
-			B *struct{ C int } `struct:",omitempty"`
-		}{A: 1},
-	},
-
-	// omit empty with values
-	{
-		`{"a": 1, "b": 2}`,
-		struct {
-			A int
-			B interface{} `struct:",omitempty"`
-		}{A: 1, B: 2},
-	},
-	{
-		`{"a": 1, "b": {"c": 2}}`,
-		struct {
-			A int
-			B map[string]interface{} `struct:",omitempty"`
-		}{A: 1, B: map[string]interface{}{"c": 2}},
-	},
-	{
-		`{"a": 1, "b":[2]}`,
-		struct {
-			A int
-			B []int `struct:",omitempty"`
-		}{A: 1, B: []int{2}},
-	},
-	{
-		`{"a": 1, "b": "test"}`,
-		struct {
-			A int
-			B string `struct:",omitempty"`
-		}{A: 1, B: "test"},
-	},
-	{
-		`{"a": 1, "b": 0}`,
-		struct {
-			A int
-			B *int `struct:",omitempty"`
-		}{A: 1, B: new(int)},
-	},
-	{
-		`{"a": 1, "b": {"c": 2}}`,
-		struct {
-			A int
-			B *struct{ C int } `struct:",omitempty"`
-		}{A: 1, B: &struct{ C int }{2}},
-	},
 }
 
 func TestIter2JsonConsistent(t *testing.T) {
-	tests := foldSamples
-	for i, test := range tests {
-		t.Logf("run test (%v): %v (%T)", i, test.json, test.value)
+	for name, test := range foldSamples() {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-		var buf bytes.Buffer
-		iter, err := NewIterator(json.NewVisitor(&buf))
-		if err != nil {
-			panic(err)
-		}
+			var buf bytes.Buffer
+			iter, err := NewIterator(json.NewVisitor(&buf))
+			if err != nil {
+				panic(err)
+			}
 
-		err = iter.Fold(test.value)
-		if err != nil {
-			t.Error(err)
-			continue
-		}
+			err = iter.Fold(test.value)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		// compare conversions did preserve type
-		assertJSON(t, test.json, buf.String())
+			// compare conversions did preserve type
+			assertJSON(t, test.json, buf.String())
+		})
 	}
 }
 
@@ -286,39 +74,66 @@ func TestUserFold(t *testing.T) {
 	}
 
 	tests := []struct {
-		v        interface{}
-		folder   interface{}
-		expected sftest.Recording
+		in   interface{}
+		fold interface{}
+		want sftest.Recording
 	}{
-		{ts, foldTsString, sftest.Recording{sftest.StringRec{tsStr}}},
-		{ts, foldTsInt, sftest.Recording{sftest.Int64Rec{tsInt}}},
-		{&ts, foldTsString, sftest.Recording{sftest.StringRec{tsStr}}},
-		{&ts, foldTsInt, sftest.Recording{sftest.Int64Rec{tsInt}}},
-		{map[string]interface{}{"ts": ts}, foldTsInt, sftest.Obj(1, structform.AnyType,
-			"ts", sftest.Int64Rec{tsInt},
-		)},
-		{map[string]interface{}{"ts": &ts}, foldTsInt, sftest.Obj(1, structform.AnyType,
-			"ts", sftest.Int64Rec{tsInt},
-		)},
-		{map[string]interface{}{"ts": ts}, foldTsString, sftest.Obj(1, structform.AnyType,
-			"ts", sftest.StringRec{tsStr},
-		)},
-		{map[string]interface{}{"ts": &ts}, foldTsString, sftest.Obj(1, structform.AnyType,
-			"ts", sftest.StringRec{tsStr},
-		)},
+		{
+			in:   ts,
+			fold: foldTsString,
+			want: sftest.Recording{sftest.StringRec{tsStr}},
+		},
+		{
+			in:   ts,
+			fold: foldTsInt,
+			want: sftest.Recording{sftest.Int64Rec{tsInt}},
+		},
+		{
+			in:   &ts,
+			fold: foldTsString,
+			want: sftest.Recording{sftest.StringRec{tsStr}},
+		},
+		{
+			in:   &ts,
+			fold: foldTsInt,
+			want: sftest.Recording{sftest.Int64Rec{tsInt}},
+		},
+		{
+			in:   map[string]interface{}{"ts": ts},
+			fold: foldTsInt,
+			want: sftest.Obj(1, structform.AnyType, "ts", sftest.Int64Rec{tsInt}),
+		},
+		{
+			in:   map[string]interface{}{"ts": &ts},
+			fold: foldTsInt,
+			want: sftest.Obj(1, structform.AnyType, "ts", sftest.Int64Rec{tsInt}),
+		},
+		{
+			in:   map[string]interface{}{"ts": ts},
+			fold: foldTsString,
+			want: sftest.Obj(1, structform.AnyType, "ts", sftest.StringRec{tsStr}),
+		},
+		{
+			in:   map[string]interface{}{"ts": &ts},
+			fold: foldTsString,
+			want: sftest.Obj(1, structform.AnyType, "ts", sftest.StringRec{tsStr}),
+		},
 	}
 
 	for i, test := range tests {
-		t.Logf("run test(%v): %#v -> %#v", i, test.v, test.expected)
+		title := fmt.Sprintf("%v - %#v -> %#v", i, test.in, test.want)
+		test := test
+		t.Run(title, func(t *testing.T) {
+			t.Parallel()
 
-		var rec sftest.Recording
-		err := Fold(test.v, &rec, Folders(test.folder))
-		if err != nil {
-			t.Error(err)
-			continue
-		}
+			var rec sftest.Recording
+			err := Fold(test.in, &rec, Folders(test.fold))
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		rec.Assert(t, test.expected)
+			rec.Assert(t, test.want)
+		})
 	}
 }
 
@@ -354,4 +169,230 @@ func normalizeJSON(in string) (string, error) {
 	}
 
 	return string(b), nil
+}
+
+func foldSamples() map[string]foldCase {
+	samples := []foldCase{
+		// primitives
+		{`null`, nil},
+		{`true`, true},
+		{`false`, false},
+		{`10`, int8(10)},
+		{`10`, int32(10)},
+		{`10`, int(10)},
+		{`10`, uint(10)},
+		{`10`, uint8(10)},
+		{`10`, uint16(10)},
+		{`10`, uint32(10)},
+		{`12340`, uint16(12340)},
+		{`1234567`, uint32(1234567)},
+		{`12345678190`, uint64(12345678190)},
+		{`-10`, int8(-10)},
+		{`-10`, int32(-10)},
+		{`-10`, int(-10)},
+		{`3.14`, float32(3.14)},
+		{`3.14`, float64(3.14)},
+		{`"test"`, "test"},
+		{`"test with \" being escaped"`, "test with \" being escaped"},
+
+		// arrays
+		{`[]`, []uint8{}},
+		{`[]`, []string{}},
+		{`[]`, []interface{}{}},
+		{`[]`, []struct{ A string }{}},
+		{`[[]]`, [][]uint8{{}}},
+		{`[[]]`, [][]string{{}}},
+		{`[[]]`, [][]interface{}{{}}},
+		{`[[]]`, [][]struct{ A string }{{}}},
+		{
+			`[null,true,false,12345678910,3.14,"test"]`,
+			[]interface{}{nil, true, false, uint64(12345678910), 3.14, "test"},
+		},
+		{`[1,2,3,4,5,6,7,8,9,10]`, []int8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+		{`[1,2,3,4,5,6,7,8,9,10]`, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+		{`[1,2,3,4,5,6,7,8,9,10]`, []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+		{`[1,2,3,4,5,6,7,8,9,10]`, []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+		{`[1,2,3,4,5,6,7,8,9,10]`, []interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+		{`["testa","testb","testc"]`, []string{"testa", "testb", "testc"}},
+		{`["testa","testb","testc"]`, []interface{}{"testa", "testb", "testc"}},
+
+		// objects
+		{`{}`, map[string]interface{}{}},
+		{`{}`, map[string]int8{}},
+		{`{}`, map[string]int64{}},
+		{`{}`, map[string]struct{ A *int }{}},
+		{`{}`, mapstr{}},
+		{`{"a":null}`, map[string]interface{}{"a": nil}},
+		{`{"a":null}`, mapstr{"a": nil}},
+		{`{"a":null}`, struct{ A *int }{}},
+		{`{"a":null}`, struct{ A *struct{ B int } }{}},
+		{`{"a":true,"b":1,"c":"test"}`, map[string]interface{}{"a": true, "b": 1, "c": "test"}},
+		{`{"a":true,"b":1,"c":"test"}`, mapstr{"a": true, "b": 1, "c": "test"}},
+		{`{"a":true,"b":1,"c":"test"}`, struct {
+			A bool
+			B int
+			C string
+		}{true, 1, "test"}},
+
+		{`{"field":[1,2,3,4,5,6,7,8,9,10]}`,
+			map[string]interface{}{
+				"field": []int8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			},
+		},
+		{`{"field":[1,2,3,4,5,6,7,8,9,10]}`,
+			map[string]interface{}{
+				"field": []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			},
+		},
+		{`{"field":[1,2,3,4,5,6,7,8,9,10]}`,
+			mapstr{
+				"field": []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			},
+		},
+		{`{"field":[1,2,3,4,5,6,7,8,9,10]}`,
+			map[string][]int{
+				"field": []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			},
+		},
+		{`{"field":[1,2,3,4,5,6,7,8,9,10]}`,
+			struct {
+				Field []int
+			}{
+				Field: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			},
+		},
+
+		// structs with inlines
+		{
+			`{"a": 1}`,
+			struct {
+				X interface{} `struct:",inline"`
+			}{X: map[string]int{"a": 1}},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				X interface{} `struct:",inline"`
+			}{X: struct{ A int }{1}},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				X interface{} `struct:",inline"`
+			}{X: &struct{ A int }{1}},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				X map[string]interface{} `struct:",inline"`
+			}{X: map[string]interface{}{"a": 1}},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				X map[string]int `struct:",inline"`
+			}{X: map[string]int{"a": 1}},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				X struct{ A int } `struct:",inline"`
+			}{X: struct{ A int }{1}},
+		},
+
+		// omit empty without values
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B interface{} `struct:",omitempty"`
+			}{A: 1},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B map[string]interface{} `struct:",omitempty"`
+			}{A: 1},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B []int `struct:",omitempty"`
+			}{A: 1},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B string `struct:",omitempty"`
+			}{A: 1},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B *int `struct:",omitempty"`
+			}{A: 1},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B *struct{ C int } `struct:",omitempty"`
+			}{A: 1},
+		},
+
+		// omit empty with values
+		{
+			`{"a": 1, "b": 2}`,
+			struct {
+				A int
+				B interface{} `struct:",omitempty"`
+			}{A: 1, B: 2},
+		},
+		{
+			`{"a": 1, "b": {"c": 2}}`,
+			struct {
+				A int
+				B map[string]interface{} `struct:",omitempty"`
+			}{A: 1, B: map[string]interface{}{"c": 2}},
+		},
+		{
+			`{"a": 1, "b":[2]}`,
+			struct {
+				A int
+				B []int `struct:",omitempty"`
+			}{A: 1, B: []int{2}},
+		},
+		{
+			`{"a": 1, "b": "test"}`,
+			struct {
+				A int
+				B string `struct:",omitempty"`
+			}{A: 1, B: "test"},
+		},
+		{
+			`{"a": 1, "b": 0}`,
+			struct {
+				A int
+				B *int `struct:",omitempty"`
+			}{A: 1, B: new(int)},
+		},
+		{
+			`{"a": 1, "b": {"c": 2}}`,
+			struct {
+				A int
+				B *struct{ C int } `struct:",omitempty"`
+			}{A: 1, B: &struct{ C int }{2}},
+		},
+	}
+
+	m := map[string]foldCase{}
+	for i, test := range samples {
+		title := fmt.Sprintf("%v - %v (%T)", i, test.json, test.value)
+		m[title] = test
+	}
+	return m
 }

--- a/gotype/unfold_test.go
+++ b/gotype/unfold_test.go
@@ -25,249 +25,17 @@ import (
 	"github.com/elastic/go-structform/json"
 )
 
-var unfoldSamples = []struct {
+type unfoldCase struct {
 	json  string
 	input interface{}
 	value interface{}
-}{
-	// primitives
-	{`null`, nil, new(interface{})},
-	{`""`, nil, new(string)},
-	{`true`, true, new(bool)},
-	{`true`, true, new(interface{})},
-	{`false`, false, new(bool)},
-	{`false`, false, new(interface{})},
-	{`null`, nil, new(*int)},
-	{`10`, int8(10), new(int8)},
-	{`10`, int8(10), new(int)},
-	{`10`, int8(10), new(*int8)},
-	{`10`, int8(10), new(*int)},
-	{`10`, int8(10), new(interface{})},
-	{`10`, int32(10), new(int64)},
-	{`10`, int32(10), new(int16)},
-	{`10`, int32(10), new(interface{})},
-	{`10`, int(10), new(int)},
-	{`10`, int(10), new(uint)},
-	{`10`, uint(10), new(uint)},
-	{`10`, uint(10), new(uint16)},
-	{`10`, uint(10), new(interface{})},
-	{`10`, uint8(10), new(int)},
-	{`10`, uint16(10), new(uint64)},
-	{`10`, uint32(10), new(uint8)},
-	{`12340`, uint16(12340), new(uint16)},
-	{`12340`, uint16(12340), new(interface{})},
-	{`1234567`, uint32(1234567), new(uint32)},
-	{`1234567`, uint32(1234567), new(int64)},
-	{`12345678190`, uint64(12345678190), new(uint64)},
-	{`12345678190`, uint64(12345678190), new(int64)},
-	{`-10`, int8(-10), new(int)},
-	{`-10`, int8(-10), new(int8)},
-	{`-10`, int8(-10), new(int32)},
-	{`-10`, int8(-10), new(int64)},
-	{`-10`, int8(-10), new(interface{})},
-	{`3.14`, float32(3.14), new(float32)},
-	{`3.14`, float32(3.14), new(interface{})},
-	{`3.14`, float64(3.14), new(float32)},
-	{`3.14`, float64(3.14), new(float64)},
-	{`3.14`, float64(3.14), new(interface{})},
-	{`"test"`, "test", new(string)},
-	{`"test"`, "test", new(interface{})},
-	{`"test with \" being escaped"`, "test with \" being escaped", new(string)},
-	{`"test with \" being escaped"`, "test with \" being escaped", new(interface{})},
-
-	// arrays
-	{`[]`, []uint8{}, new(interface{})},
-	{`[]`, []uint8{}, new([]uint8)},
-	{`[]`, []interface{}{}, new([]interface{})},
-	{`[]`, []interface{}{}, &[]struct{ A string }{}},
-	{`[1,2,3]`, []uint8{1, 2, 3}, new(interface{})},
-	{`[1,2,3]`, []uint8{1, 2, 3}, &[]uint8{0, 0, 0}},
-	{`[1,2,3]`, []uint8{1, 2, 3}, &[]uint8{0, 0, 0, 4}},
-	{`[1,2,3]`, []uint8{1, 2, 3}, &[]uint8{}},
-	{`[1,2,3]`, []interface{}{1, 2, 3}, &[]uint8{}},
-	{`[1,2,3]`, []interface{}{1, 2, 3}, new([]uint8)},
-	{`[1,2,3]`, []int{1, 2, 3}, &[]interface{}{}},
-	{`[1,2,3]`, []int{1, 2, 3}, &[]interface{}{nil, nil, nil, 4}},
-
-	{`[1]`, []uint8{1}, &[]uint8{0, 2, 3}},
-	{`[1,2]`, []uint8{1, 2}, &[]uint8{0, 0, 3}},
-	{`[1,2]`, []interface{}{1, 2}, &[]uint{0, 0, 3}},
-	{`[1,2]`, []interface{}{1, 2}, &[]interface{}{0, 0, 3}},
-	{`["a","b"]`, []string{"a", "b"}, &[]interface{}{}},
-	{`["a","b"]`, []string{"a", "b"}, &[]interface{}{nil, nil}},
-	{`["a","b"]`, []string{"a", "b"}, &[]string{}},
-	{`["a","b"]`, []string{"a", "b"}, new([]string)},
-	{`[null,true,false]`,
-		[]interface{}{nil, true, false},
-		new(interface{})},
-	{`[null,true]`,
-		[]interface{}{nil, true},
-		new(interface{})},
-	{`[null,true,false,123,3.14,"test"]`,
-		[]interface{}{nil, true, false, 123, 3.14, "test"},
-		new(interface{})},
-	{`[null,true,false,123,3.14,"test"]`,
-		[]interface{}{nil, true, false, 123, 3.14, "test"},
-		&[]interface{}{}},
-
-	{`[1,2,3]`, []int{1, 2, 3}, &[]*int{}},
-	{`[1,null,3]`, []interface{}{1, nil, 3}, &[]*int{}},
-
-	// nested arrays
-	{`[[]]`, []interface{}{[]uint{}}, new(interface{})},
-	{`[]`, []interface{}{}, &[]interface{}{[]interface{}{1}}},
-	{`[]`, []interface{}{}, &[][]int{}},
-	{`[]`, []interface{}{}, &[][]int{{1}}},
-	{`[[1]]`, []interface{}{[]interface{}{1}}, &[][]int{}},
-	{`[[1,2,3],[4,5,6]]`,
-		[]interface{}{[]interface{}{1, 2, 3}, []interface{}{4, 5, 6}},
-		new(interface{})},
-	{`[[1],[4]]`,
-		[]interface{}{[]interface{}{1}, []interface{}{4}},
-		&[]interface{}{[]interface{}{0, 2, 3}}},
-	{`[[1],[4],[6]]`,
-		[]interface{}{[]interface{}{1}, []interface{}{4}, []interface{}{6}},
-		&[]interface{}{
-			[]interface{}{0, 2, 3},
-			[]interface{}{0, 5},
-		}},
-	{`[[1],[4],[6]]`,
-		[]interface{}{[]interface{}{1}, []interface{}{4}, []interface{}{6}},
-		&[][]int{
-			{0, 2, 3},
-			{0, 5},
-		},
-	},
-
-	// maps
-	{`{}`, map[string]interface{}{}, new(interface{})},
-	{`{}`, map[string]interface{}{}, &map[string]interface{}{}},
-	{`{"a":1}`, map[string]int{"a": 1}, new(interface{})},
-	{`{"a":1}`, map[string]int{"a": 1}, &map[string]interface{}{}},
-	{`{"a":1}`, map[string]int{"a": 1}, &map[string]interface{}{"a": 2}},
-	{`{"a":1}`, map[string]int{"a": 1}, &map[string]int{}},
-	{`{"a":1}`, map[string]int{"a": 1}, &map[string]int{"a": 2}},
-	{`{"a":1}`, struct{ A int }{1}, &map[string]interface{}{}},
-	{`{"a":1}`, struct{ A int }{1}, &map[string]int{}},
-	{`{"a":1,"b":"b","c":true}`,
-		map[string]interface{}{"a": 1, "b": "b", "c": true},
-		new(interface{}),
-	},
-
-	// nested maps
-	{`{"a":{}}`, map[string]interface{}{"a": map[string]interface{}{}}, new(interface{})},
-	{`{"a":{}}`,
-		map[string]interface{}{"a": map[string]interface{}{}},
-		&map[string]interface{}{}},
-	{`{"a":{}}`,
-		map[string]interface{}{"a": map[string]interface{}{}},
-		&map[string]interface{}{"a": nil}},
-	{`{"a":{}}`,
-		map[string]interface{}{"a": map[string]interface{}{}},
-		&map[string]map[string]string{"a": nil}},
-	{`{"0":{"a":1,"b":2,"c":3},"1":{"e":5,"f":6}}`,
-		map[string]map[string]int{
-			"0": {"a": 1, "b": 2, "c": 3},
-			"1": {"e": 5, "f": 6},
-		},
-		new(interface{})},
-	{`{"0":{"a":1,"b":2,"c":3},"1":{"e":5,"f":6}}`,
-		map[string]map[string]int{
-			"0": {"a": 1, "b": 2, "c": 3},
-			"1": {"e": 5, "f": 6},
-		},
-		&map[string]interface{}{}},
-	{`{"0":{"a":1,"b":2,"c":3},"1":{"e":5,"f":6}}`,
-		map[string]map[string]int{
-			"0": {"a": 1, "b": 2, "c": 3},
-			"1": {"e": 5, "f": 6},
-		},
-		&map[string]map[string]int64{}},
-	{`{"0":{"a":1}}`,
-		map[string]map[string]int{
-			"0": {"a": 1},
-		},
-		&map[string]interface{}{
-			"0": map[string]int{"b": 2, "c": 3},
-		}},
-	{`{"0":{"a":1},"1":{"e":5}}`,
-		map[string]map[string]int{
-			"0": {"a": 1},
-			"1": {"e": 5},
-		},
-		&map[string]interface{}{
-			"0": map[string]int{"b": 2, "c": 3},
-			"1": map[string]interface{}{"f": 6, "e": 0},
-		}},
-	{`{"0":{"a":1},"1":{"e":5}}`,
-		map[string]map[string]int{
-			"0": {"a": 1},
-			"1": {"e": 5},
-		},
-		&map[string]map[string]uint{
-			"0": {"b": 2, "c": 3},
-			"1": {"f": 6, "e": 0},
-		}},
-
-	// map in array
-	{`[{}]`, []interface{}{map[string]interface{}{}}, new(interface{})},
-	{`[{}]`, []interface{}{map[string]interface{}{}}, &[]map[string]int{}},
-	{`[{"a":1}]`, []map[string]int{{"a": 1}}, new(interface{})},
-	{`[{"a":1}]`, []map[string]int{{"a": 1}}, &[]interface{}{}},
-	{`[{"a":1}]`, []map[string]int{{"a": 1}}, &[]map[string]interface{}{}},
-	{`[{"a":1}]`, []map[string]int{{"a": 1}}, &[]map[string]interface{}{{"a": 2}}},
-	{`[{"a":1,"b":2}]`, []map[string]int{{"a": 1}}, &[]map[string]int{{"b": 2}}},
-	{`[{"a":1},{"b":2}]`, []map[string]int{{"a": 1}, {"b": 2}}, &[]map[string]int{}},
-	{`[{"a":1},{"b":"b"},{"c":true}]`,
-		[]map[string]interface{}{{"a": 1}, {"b": "b"}, {"c": true}},
-		new(interface{})},
-
-	// array in map
-	{`{"a": []}`, map[string]interface{}{"a": []int{}}, new(interface{})},
-	{`{"a":[1,2],"b":[3]}`, map[string][]int{"a": {1, 2}, "b": {3}}, new(interface{})},
-	{`{"a":[1,2],"b":[3]}`, map[string][]int{"a": {1, 2}, "b": {3}},
-		&map[string][]int{}},
-	{`{"a":[1,2],"b":[3,4,5]}`, map[string][]int{"a": {1, 2}, "b": {3, 4, 5}},
-		&map[string][]int{"a": {0, 2}, "b": {0}}},
-
-	// struct
-	{`{"a":1}`, map[string]int{"a": 1}, &struct{ A int }{}},
-	{`{"a":1}`, map[string]int{"a": 1}, &struct{ A *int }{}},
-	{`{"a": 1, "c": 2}`, map[string]int{"a": 1}, &struct{ A, b, C int }{b: 1, C: 2}},
-	{`{"a": {"c": 2}, "b": 1}`,
-		map[string]interface{}{"a": map[string]int{"c": 2}},
-		&struct {
-			A struct{ C int }
-			B int
-		}{B: 1},
-	},
-	{`{"a": 1}`,
-		map[string]interface{}{"a": 1},
-		&struct {
-			S struct {
-				A int
-			} `struct:",inline"`
-		}{},
-	},
-	{`{"a":{"b":{"c":1}}}`,
-		map[string]interface{}{
-			"a": map[string]interface{}{
-				"b": map[string]int{
-					"c": 1,
-				},
-			},
-		},
-		&struct{ A struct{ B struct{ C int } } }{},
-	},
 }
 
 func TestFoldUnfoldConsistent(t *testing.T) {
-	tests := unfoldSamples
-	for i, test := range tests {
+	for name, test := range unfoldSamples() {
 		test := test
-		title := fmt.Sprintf("run test %v: %v (%T -> %T)", i, test.json, test.input, test.value)
-		t.Run(title, func(t *testing.T) {
-			t.Log(title)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
 			u, err := NewUnfolder(test.value)
 			if err != nil {
@@ -296,47 +64,42 @@ func TestFoldUnfoldConsistent(t *testing.T) {
 }
 
 func TestUnfoldJsonInto(t *testing.T) {
-	tests := unfoldSamples
-	for i, test := range tests {
-		t.Logf("run test (%v): %v (%T -> %T)", i, test.json, test.input, test.value)
+	for name, test := range unfoldSamples() {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-		un, err := NewUnfolder(test.value)
-		if err != nil {
-			t.Fatal(err)
-		}
+			un, err := NewUnfolder(test.value)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		dec := json.NewParser(un)
-		input := test.json
+			dec := json.NewParser(un)
+			input := test.json
 
-		err = dec.ParseString(input)
-		if err != nil {
-			t.Error(err)
-			continue
-		}
+			err = dec.ParseString(input)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		// check state valid by processing a second time
-		if err = un.SetTarget(test.value); err != nil {
-			t.Error(err)
-			continue
-		}
+			// check state valid by processing a second time
+			if err = un.SetTarget(test.value); err != nil {
+				t.Fatal(err)
+			}
 
-		err = dec.ParseString(input)
-		if err != nil {
-			t.Error(err)
-			continue
-		}
+			err = dec.ParseString(input)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		// clear unfolder state.
-		un.Reset()
+			// clear unfolder state.
+			un.Reset()
+		})
 	}
 }
 
 func BenchmarkUnfoldJsonInto(b *testing.B) {
-	tests := unfoldSamples
-	for i, test := range tests {
-		name := fmt.Sprintf("%v (%T->%T)", test.json, test.input, test.value)
-		b.Logf("run test (%v): %v", i, name)
-
+	for name, test := range unfoldSamples() {
 		un, err := NewUnfolder(test.value)
 		if err != nil {
 			b.Fatal(err)
@@ -346,8 +109,7 @@ func BenchmarkUnfoldJsonInto(b *testing.B) {
 		input := test.json
 		// parse once to reset state for use of 'setTarget' in benchmark
 		if err := dec.ParseString(input); err != nil {
-			b.Error(err)
-			continue
+			b.Fatal(err)
 		}
 
 		b.Run(name, func(b *testing.B) {
@@ -360,4 +122,245 @@ func BenchmarkUnfoldJsonInto(b *testing.B) {
 			}
 		})
 	}
+}
+
+func unfoldSamples() map[string]unfoldCase {
+	samples := []unfoldCase{
+		// primitives
+		{`null`, nil, new(interface{})},
+		{`""`, nil, new(string)},
+		{`true`, true, new(bool)},
+		{`true`, true, new(interface{})},
+		{`false`, false, new(bool)},
+		{`false`, false, new(interface{})},
+		{`null`, nil, new(*int)},
+		{`10`, int8(10), new(int8)},
+		{`10`, int8(10), new(int)},
+		{`10`, int8(10), new(*int8)},
+		{`10`, int8(10), new(*int)},
+		{`10`, int8(10), new(interface{})},
+		{`10`, int32(10), new(int64)},
+		{`10`, int32(10), new(int16)},
+		{`10`, int32(10), new(interface{})},
+		{`10`, int(10), new(int)},
+		{`10`, int(10), new(uint)},
+		{`10`, uint(10), new(uint)},
+		{`10`, uint(10), new(uint16)},
+		{`10`, uint(10), new(interface{})},
+		{`10`, uint8(10), new(int)},
+		{`10`, uint16(10), new(uint64)},
+		{`10`, uint32(10), new(uint8)},
+		{`12340`, uint16(12340), new(uint16)},
+		{`12340`, uint16(12340), new(interface{})},
+		{`1234567`, uint32(1234567), new(uint32)},
+		{`1234567`, uint32(1234567), new(int64)},
+		{`12345678190`, uint64(12345678190), new(uint64)},
+		{`12345678190`, uint64(12345678190), new(int64)},
+		{`-10`, int8(-10), new(int)},
+		{`-10`, int8(-10), new(int8)},
+		{`-10`, int8(-10), new(int32)},
+		{`-10`, int8(-10), new(int64)},
+		{`-10`, int8(-10), new(interface{})},
+		{`3.14`, float32(3.14), new(float32)},
+		{`3.14`, float32(3.14), new(interface{})},
+		{`3.14`, float64(3.14), new(float32)},
+		{`3.14`, float64(3.14), new(float64)},
+		{`3.14`, float64(3.14), new(interface{})},
+		{`"test"`, "test", new(string)},
+		{`"test"`, "test", new(interface{})},
+		{`"test with \" being escaped"`, "test with \" being escaped", new(string)},
+		{`"test with \" being escaped"`, "test with \" being escaped", new(interface{})},
+
+		// arrays
+		{`[]`, []uint8{}, new(interface{})},
+		{`[]`, []uint8{}, new([]uint8)},
+		{`[]`, []interface{}{}, new([]interface{})},
+		{`[]`, []interface{}{}, &[]struct{ A string }{}},
+		{`[1,2,3]`, []uint8{1, 2, 3}, new(interface{})},
+		{`[1,2,3]`, []uint8{1, 2, 3}, &[]uint8{0, 0, 0}},
+		{`[1,2,3]`, []uint8{1, 2, 3}, &[]uint8{0, 0, 0, 4}},
+		{`[1,2,3]`, []uint8{1, 2, 3}, &[]uint8{}},
+		{`[1,2,3]`, []interface{}{1, 2, 3}, &[]uint8{}},
+		{`[1,2,3]`, []interface{}{1, 2, 3}, new([]uint8)},
+		{`[1,2,3]`, []int{1, 2, 3}, &[]interface{}{}},
+		{`[1,2,3]`, []int{1, 2, 3}, &[]interface{}{nil, nil, nil, 4}},
+
+		{`[1]`, []uint8{1}, &[]uint8{0, 2, 3}},
+		{`[1,2]`, []uint8{1, 2}, &[]uint8{0, 0, 3}},
+		{`[1,2]`, []interface{}{1, 2}, &[]uint{0, 0, 3}},
+		{`[1,2]`, []interface{}{1, 2}, &[]interface{}{0, 0, 3}},
+		{`["a","b"]`, []string{"a", "b"}, &[]interface{}{}},
+		{`["a","b"]`, []string{"a", "b"}, &[]interface{}{nil, nil}},
+		{`["a","b"]`, []string{"a", "b"}, &[]string{}},
+		{`["a","b"]`, []string{"a", "b"}, new([]string)},
+		{`[null,true,false]`,
+			[]interface{}{nil, true, false},
+			new(interface{})},
+		{`[null,true]`,
+			[]interface{}{nil, true},
+			new(interface{})},
+		{`[null,true,false,123,3.14,"test"]`,
+			[]interface{}{nil, true, false, 123, 3.14, "test"},
+			new(interface{})},
+		{`[null,true,false,123,3.14,"test"]`,
+			[]interface{}{nil, true, false, 123, 3.14, "test"},
+			&[]interface{}{}},
+
+		{`[1,2,3]`, []int{1, 2, 3}, &[]*int{}},
+		{`[1,null,3]`, []interface{}{1, nil, 3}, &[]*int{}},
+
+		// nested arrays
+		{`[[]]`, []interface{}{[]uint{}}, new(interface{})},
+		{`[]`, []interface{}{}, &[]interface{}{[]interface{}{1}}},
+		{`[]`, []interface{}{}, &[][]int{}},
+		{`[]`, []interface{}{}, &[][]int{{1}}},
+		{`[[1]]`, []interface{}{[]interface{}{1}}, &[][]int{}},
+		{`[[1,2,3],[4,5,6]]`,
+			[]interface{}{[]interface{}{1, 2, 3}, []interface{}{4, 5, 6}},
+			new(interface{})},
+		{`[[1],[4]]`,
+			[]interface{}{[]interface{}{1}, []interface{}{4}},
+			&[]interface{}{[]interface{}{0, 2, 3}}},
+		{`[[1],[4],[6]]`,
+			[]interface{}{[]interface{}{1}, []interface{}{4}, []interface{}{6}},
+			&[]interface{}{
+				[]interface{}{0, 2, 3},
+				[]interface{}{0, 5},
+			}},
+		{`[[1],[4],[6]]`,
+			[]interface{}{[]interface{}{1}, []interface{}{4}, []interface{}{6}},
+			&[][]int{
+				{0, 2, 3},
+				{0, 5},
+			},
+		},
+
+		// maps
+		{`{}`, map[string]interface{}{}, new(interface{})},
+		{`{}`, map[string]interface{}{}, &map[string]interface{}{}},
+		{`{"a":1}`, map[string]int{"a": 1}, new(interface{})},
+		{`{"a":1}`, map[string]int{"a": 1}, &map[string]interface{}{}},
+		{`{"a":1}`, map[string]int{"a": 1}, &map[string]interface{}{"a": 2}},
+		{`{"a":1}`, map[string]int{"a": 1}, &map[string]int{}},
+		{`{"a":1}`, map[string]int{"a": 1}, &map[string]int{"a": 2}},
+		{`{"a":1}`, struct{ A int }{1}, &map[string]interface{}{}},
+		{`{"a":1}`, struct{ A int }{1}, &map[string]int{}},
+		{`{"a":1,"b":"b","c":true}`,
+			map[string]interface{}{"a": 1, "b": "b", "c": true},
+			new(interface{}),
+		},
+
+		// nested maps
+		{`{"a":{}}`, map[string]interface{}{"a": map[string]interface{}{}}, new(interface{})},
+		{`{"a":{}}`,
+			map[string]interface{}{"a": map[string]interface{}{}},
+			&map[string]interface{}{}},
+		{`{"a":{}}`,
+			map[string]interface{}{"a": map[string]interface{}{}},
+			&map[string]interface{}{"a": nil}},
+		{`{"a":{}}`,
+			map[string]interface{}{"a": map[string]interface{}{}},
+			&map[string]map[string]string{"a": nil}},
+		{`{"0":{"a":1,"b":2,"c":3},"1":{"e":5,"f":6}}`,
+			map[string]map[string]int{
+				"0": {"a": 1, "b": 2, "c": 3},
+				"1": {"e": 5, "f": 6},
+			},
+			new(interface{})},
+		{`{"0":{"a":1,"b":2,"c":3},"1":{"e":5,"f":6}}`,
+			map[string]map[string]int{
+				"0": {"a": 1, "b": 2, "c": 3},
+				"1": {"e": 5, "f": 6},
+			},
+			&map[string]interface{}{}},
+		{`{"0":{"a":1,"b":2,"c":3},"1":{"e":5,"f":6}}`,
+			map[string]map[string]int{
+				"0": {"a": 1, "b": 2, "c": 3},
+				"1": {"e": 5, "f": 6},
+			},
+			&map[string]map[string]int64{}},
+		{`{"0":{"a":1}}`,
+			map[string]map[string]int{
+				"0": {"a": 1},
+			},
+			&map[string]interface{}{
+				"0": map[string]int{"b": 2, "c": 3},
+			}},
+		{`{"0":{"a":1},"1":{"e":5}}`,
+			map[string]map[string]int{
+				"0": {"a": 1},
+				"1": {"e": 5},
+			},
+			&map[string]interface{}{
+				"0": map[string]int{"b": 2, "c": 3},
+				"1": map[string]interface{}{"f": 6, "e": 0},
+			}},
+		{`{"0":{"a":1},"1":{"e":5}}`,
+			map[string]map[string]int{
+				"0": {"a": 1},
+				"1": {"e": 5},
+			},
+			&map[string]map[string]uint{
+				"0": {"b": 2, "c": 3},
+				"1": {"f": 6, "e": 0},
+			}},
+
+		// map in array
+		{`[{}]`, []interface{}{map[string]interface{}{}}, new(interface{})},
+		{`[{}]`, []interface{}{map[string]interface{}{}}, &[]map[string]int{}},
+		{`[{"a":1}]`, []map[string]int{{"a": 1}}, new(interface{})},
+		{`[{"a":1}]`, []map[string]int{{"a": 1}}, &[]interface{}{}},
+		{`[{"a":1}]`, []map[string]int{{"a": 1}}, &[]map[string]interface{}{}},
+		{`[{"a":1}]`, []map[string]int{{"a": 1}}, &[]map[string]interface{}{{"a": 2}}},
+		{`[{"a":1,"b":2}]`, []map[string]int{{"a": 1}}, &[]map[string]int{{"b": 2}}},
+		{`[{"a":1},{"b":2}]`, []map[string]int{{"a": 1}, {"b": 2}}, &[]map[string]int{}},
+		{`[{"a":1},{"b":"b"},{"c":true}]`,
+			[]map[string]interface{}{{"a": 1}, {"b": "b"}, {"c": true}},
+			new(interface{})},
+
+		// array in map
+		{`{"a": []}`, map[string]interface{}{"a": []int{}}, new(interface{})},
+		{`{"a":[1,2],"b":[3]}`, map[string][]int{"a": {1, 2}, "b": {3}}, new(interface{})},
+		{`{"a":[1,2],"b":[3]}`, map[string][]int{"a": {1, 2}, "b": {3}},
+			&map[string][]int{}},
+		{`{"a":[1,2],"b":[3,4,5]}`, map[string][]int{"a": {1, 2}, "b": {3, 4, 5}},
+			&map[string][]int{"a": {0, 2}, "b": {0}}},
+
+		// struct
+		{`{"a":1}`, map[string]int{"a": 1}, &struct{ A int }{}},
+		{`{"a":1}`, map[string]int{"a": 1}, &struct{ A *int }{}},
+		{`{"a": 1, "c": 2}`, map[string]int{"a": 1}, &struct{ A, b, C int }{b: 1, C: 2}},
+		{`{"a": {"c": 2}, "b": 1}`,
+			map[string]interface{}{"a": map[string]int{"c": 2}},
+			&struct {
+				A struct{ C int }
+				B int
+			}{B: 1},
+		},
+		{`{"a": 1}`,
+			map[string]interface{}{"a": 1},
+			&struct {
+				S struct {
+					A int
+				} `struct:",inline"`
+			}{},
+		},
+		{`{"a":{"b":{"c":1}}}`,
+			map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": map[string]int{
+						"c": 1,
+					},
+				},
+			},
+			&struct{ A struct{ B struct{ C int } } }{},
+		},
+	}
+
+	m := map[string]unfoldCase{}
+	for i, test := range samples {
+		title := fmt.Sprintf("%v: %v (%T -> %T)", i, test.json, test.input, test.value)
+		m[title] = test
+	}
+	return m
 }

--- a/sftest/sftest.go
+++ b/sftest/sftest.go
@@ -23,8 +23,9 @@ import (
 	"fmt"
 	"testing"
 
-	structform "github.com/elastic/go-structform"
 	"github.com/stretchr/testify/assert"
+
+	structform "github.com/elastic/go-structform"
 )
 
 type Recording []Record
@@ -302,6 +303,8 @@ func TestEncodeParseConsistent(
 
 		title := fmt.Sprintf("test %v: %#v => %v", i, sample, expected)
 		t.Run(title, func(t *testing.T) {
+			t.Parallel()
+
 			enc, dec := constr()
 
 			err = sample.Replay(enc)


### PR DESCRIPTION
- Update some very old tests to use t.Run.
- Better isolate go type tests by creating and allocating state for test samples on the fly
- Randomize test order by using map[string]<testCase>