### PR TITLE
Feature omit

### DIFF
--- a/gotype/fold_reflect.go
+++ b/gotype/fold_reflect.go
@@ -214,6 +214,11 @@ func buildFieldFold(C *foldContext, t reflect.Type, idx int) (reFoldFn, error) {
 		return nil, errInlineAndOmitEmpty
 	}
 
+	if tagOpts.omit {
+		// ignore omitted fields
+		return nil, nil
+	}
+
 	if tagOpts.squash {
 		return buildFieldFoldInline(C, t, idx, tagOpts.omitEmpty)
 	}

--- a/gotype/fold_test.go
+++ b/gotype/fold_test.go
@@ -387,6 +387,22 @@ func foldSamples() map[string]foldCase {
 				B *struct{ C int } `struct:",omitempty"`
 			}{A: 1, B: &struct{ C int }{2}},
 		},
+
+		// omit
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B int `struct:"-"`
+			}{A: 1, B: 2},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B int `struct:",omit"`
+			}{A: 1, B: 2},
+		},
 	}
 
 	m := map[string]foldCase{}

--- a/gotype/tags.go
+++ b/gotype/tags.go
@@ -22,11 +22,13 @@ import "strings"
 type tagOptions struct {
 	squash    bool
 	omitEmpty bool
+	omit      bool
 }
 
 var defaultTagOptions = tagOptions{
 	squash:    false,
 	omitEmpty: false,
+	omit:      false,
 }
 
 func parseTags(tag string) (string, tagOptions) {
@@ -34,6 +36,13 @@ func parseTags(tag string) (string, tagOptions) {
 	if len(s) == 0 {
 		return "", defaultTagOptions
 	}
+
+	if s[0] == "-" {
+		opts := defaultTagOptions
+		opts.omit = true
+		return "", opts
+	}
+
 	opts := defaultTagOptions
 	for _, opt := range s[1:] {
 		switch strings.TrimSpace(opt) {
@@ -41,6 +50,8 @@ func parseTags(tag string) (string, tagOptions) {
 			opts.squash = true
 		case "omitempty":
 			opts.omitEmpty = true
+		case "omit":
+			opts.omit = true
 		}
 	}
 	return strings.TrimSpace(s[0]), opts

--- a/gotype/unfold_struct.go
+++ b/gotype/unfold_struct.go
@@ -77,6 +77,10 @@ func fieldUnfolders(ctx *unfoldCtx, t reflect.Type) (map[string]fieldUnfolder, e
 		}
 
 		tagName, tagOpts := parseTags(st.Tag.Get(ctx.opts.tag))
+		if tagOpts.omit {
+			continue
+		}
+
 		if tagOpts.squash {
 			if st.Type.Kind() != reflect.Struct {
 				return nil, errSquashNeedObject

--- a/gotype/unfold_test.go
+++ b/gotype/unfold_test.go
@@ -355,6 +355,22 @@ func unfoldSamples() map[string]unfoldCase {
 			},
 			&struct{ A struct{ B struct{ C int } } }{},
 		},
+		{
+			`{"a": 1}`,
+			map[string]interface{}{"a": 1, "b": 2},
+			&struct {
+				A int
+				B int `struct:"-"`
+			}{},
+		},
+		{
+			`{"a": 1}`,
+			map[string]interface{}{"a": 1, "b": 2},
+			&struct {
+				A int
+				B int `struct:",omit"`
+			}{},
+		},
 	}
 
 	m := map[string]unfoldCase{}


### PR DESCRIPTION
Add support to ingore struct fields when encoding and decoding:
- field is ignored if name in struct tag is `-`
- field is ignored if struct tag option `omit` is set.

Depends on #12