### PR TITLE
Customer user unfolders

### DIFF
--- a/gotype/0gen.go
+++ b/gotype/0gen.go
@@ -27,5 +27,6 @@ package gotype
 //go:generate mktmpl -f -o unfold_map.generated.go unfold_map.yml
 //go:generate mktmpl -f -o unfold_refl.generated.go unfold_refl.yml
 //go:generate mktmpl -f -o unfold_ignore.generated.go unfold_ignore.yml
+//go:generate mktmpl -f -o unfold_user_primitive.generated.go unfold_user_primitive.yml
 
 // go:generate mktmpl -f -o unfold_sel_generated.go unfold_sel.yml

--- a/gotype/0gen.go
+++ b/gotype/0gen.go
@@ -28,5 +28,6 @@ package gotype
 //go:generate mktmpl -f -o unfold_refl.generated.go unfold_refl.yml
 //go:generate mktmpl -f -o unfold_ignore.generated.go unfold_ignore.yml
 //go:generate mktmpl -f -o unfold_user_primitive.generated.go unfold_user_primitive.yml
+//go:generate mktmpl -f -o unfold_user_processing.generated.go unfold_user_processing.yml
 
 // go:generate mktmpl -f -o unfold_sel_generated.go unfold_sel.yml

--- a/gotype/defs.go
+++ b/gotype/defs.go
@@ -20,7 +20,7 @@ package gotype
 import (
 	"reflect"
 
-	"github.com/elastic/go-structform"
+	structform "github.com/elastic/go-structform"
 	"github.com/elastic/go-structform/internal/unsafe"
 )
 

--- a/gotype/fold.go
+++ b/gotype/fold.go
@@ -20,7 +20,7 @@ package gotype
 import (
 	"reflect"
 
-	"github.com/elastic/go-structform"
+	structform "github.com/elastic/go-structform"
 )
 
 type foldFn func(c *foldContext, v interface{}) error
@@ -46,16 +46,16 @@ type foldContext struct {
 	opts    options
 }
 
-func Fold(v interface{}, vs structform.Visitor, opts ...Option) error {
+func Fold(v interface{}, vs structform.Visitor, opts ...FoldOption) error {
 	if it, err := NewIterator(vs, opts...); err == nil {
 		return it.Fold(v)
 	}
 	return nil
 }
 
-func NewIterator(vs structform.Visitor, opts ...Option) (*Iterator, error) {
+func NewIterator(vs structform.Visitor, opts ...FoldOption) (*Iterator, error) {
 	reg := newTypeFoldRegistry()
-	O, err := applyOpts(opts)
+	O, err := applyFoldOpts(opts)
 	if err != nil {
 		return nil, err
 	}

--- a/gotype/fold_inline.go
+++ b/gotype/fold_inline.go
@@ -20,7 +20,7 @@ package gotype
 import (
 	"reflect"
 
-	"github.com/elastic/go-structform"
+	structform "github.com/elastic/go-structform"
 	"github.com/elastic/go-structform/visitors"
 )
 

--- a/gotype/fold_opts.go
+++ b/gotype/fold_opts.go
@@ -19,33 +19,32 @@ package gotype
 
 import "reflect"
 
-type initOptions struct {
+type initFoldOptions struct {
 	foldFns map[reflect.Type]reFoldFn
 }
 
-type Option func(*initOptions) error
+type FoldOption func(*initFoldOptions) error
 
-func applyOpts(opts []Option) (initOptions, error) {
-	i := initOptions{}
+func applyFoldOpts(opts []FoldOption) (i initFoldOptions, err error) {
 	for _, o := range opts {
-		if err := o(&i); err != nil {
-			return initOptions{}, err
+		if err = o(&i); err != nil {
+			break
 		}
 	}
-	return i, nil
+	return i, err
 }
 
-func Folders(in ...interface{}) Option {
+func Folders(in ...interface{}) FoldOption {
 	folders, err := makeUserFoldFns(in)
 	if err != nil {
-		return func(_ *initOptions) error { return err }
+		return func(_ *initFoldOptions) error { return err }
 	}
 
 	if len(folders) == 0 {
-		return func(*initOptions) error { return nil }
+		return func(*initFoldOptions) error { return nil }
 	}
 
-	return func(o *initOptions) error {
+	return func(o *initFoldOptions) error {
 		if o.foldFns == nil {
 			o.foldFns = map[reflect.Type]reFoldFn{}
 		}

--- a/gotype/fold_refl_sel.generated.go
+++ b/gotype/fold_refl_sel.generated.go
@@ -22,7 +22,7 @@ import "reflect"
 
 var _reflPrimitivesMapping = map[reflect.Type]reFoldFn{
 
-	tBool: reFoldBool,
+	tBool:                         reFoldBool,
 	reflect.SliceOf(tBool):        reFoldArrBool,
 	reflect.MapOf(tString, tBool): reFoldMapBool,
 
@@ -30,7 +30,7 @@ var _reflPrimitivesMapping = map[reflect.Type]reFoldFn{
 	reflect.SliceOf(tString):        reFoldArrString,
 	reflect.MapOf(tString, tString): reFoldMapString,
 
-	tUint: reFoldUint,
+	tUint:                         reFoldUint,
 	reflect.SliceOf(tUint):        reFoldArrUint,
 	reflect.MapOf(tString, tUint): reFoldMapUint,
 
@@ -50,11 +50,11 @@ var _reflPrimitivesMapping = map[reflect.Type]reFoldFn{
 	reflect.SliceOf(tUint64):        reFoldArrUint64,
 	reflect.MapOf(tString, tUint64): reFoldMapUint64,
 
-	tInt: reFoldInt,
+	tInt:                         reFoldInt,
 	reflect.SliceOf(tInt):        reFoldArrInt,
 	reflect.MapOf(tString, tInt): reFoldMapInt,
 
-	tInt8: reFoldInt8,
+	tInt8:                         reFoldInt8,
 	reflect.SliceOf(tInt8):        reFoldArrInt8,
 	reflect.MapOf(tString, tInt8): reFoldMapInt8,
 

--- a/gotype/unfold_lookup_go.generated.go
+++ b/gotype/unfold_lookup_go.generated.go
@@ -292,7 +292,13 @@ func lookupGoPtrUnfolder(t reflect.Type) ptrUnfolder {
 }
 
 func lookupReflUnfolder(ctx *unfoldCtx, t reflect.Type) (reflUnfolder, error) {
-	if f := unfoldRegistry.find(t); f != nil {
+	if ctx.userReg != nil {
+		if f := ctx.userReg[t]; f != nil {
+			return f, nil
+		}
+	}
+
+	if f := ctx.reg.find(t); f != nil {
 		return f, nil
 	}
 
@@ -301,7 +307,7 @@ func lookupReflUnfolder(ctx *unfoldCtx, t reflect.Type) (reflUnfolder, error) {
 		return nil, err
 	}
 
-	unfoldRegistry.set(t, f)
+	ctx.reg.set(t, f)
 	return f, nil
 }
 

--- a/gotype/unfold_lookup_go.generated.go
+++ b/gotype/unfold_lookup_go.generated.go
@@ -23,6 +23,55 @@ import (
 	"unsafe"
 )
 
+func lookupUserPrimitiveConstructor(t reflect.Type) func(reflect.Value) ptrUnfolder {
+	switch t.Kind() {
+	case reflect.Bool:
+		return newUserUnfolderBool
+
+	case reflect.String:
+		return newUserUnfolderString
+
+	case reflect.Uint:
+		return newUserUnfolderUint
+
+	case reflect.Uint8:
+		return newUserUnfolderUint8
+
+	case reflect.Uint16:
+		return newUserUnfolderUint16
+
+	case reflect.Uint32:
+		return newUserUnfolderUint32
+
+	case reflect.Uint64:
+		return newUserUnfolderUint64
+
+	case reflect.Int:
+		return newUserUnfolderInt
+
+	case reflect.Int8:
+		return newUserUnfolderInt8
+
+	case reflect.Int16:
+		return newUserUnfolderInt16
+
+	case reflect.Int32:
+		return newUserUnfolderInt32
+
+	case reflect.Int64:
+		return newUserUnfolderInt64
+
+	case reflect.Float32:
+		return newUserUnfolderFloat32
+
+	case reflect.Float64:
+		return newUserUnfolderFloat64
+
+	default:
+		return nil
+	}
+}
+
 func lookupGoTypeUnfolder(to interface{}) (unsafe.Pointer, ptrUnfolder) {
 	switch ptr := to.(type) {
 	case *interface{}:

--- a/gotype/unfold_lookup_go.yml
+++ b/gotype/unfold_lookup_go.yml
@@ -94,9 +94,9 @@ main: |
     return nil
   }
 
-  func lookupReflUnfolder(ctx *unfoldCtx, t reflect.Type) (reflUnfolder, error) {
-    if ctx.userReg != nil {
-      if f := ctx.userReg[t]; f != nil {
+  func lookupReflUnfolder(ctx *unfoldCtx, t reflect.Type, withUser bool) (reflUnfolder, error) {
+    if withUser {
+      if f := lookupReflUser(ctx, t); f != nil {
         return f, nil
       }
     }
@@ -112,6 +112,13 @@ main: |
 
     ctx.reg.set(t, f)
     return f, nil
+  }
+
+  func lookupReflUser(ctx *unfoldCtx, t reflect.Type) reflUnfolder {
+    if ctx.userReg != nil {
+      return ctx.userReg[t]
+    }
+    return nil
   }
 
   func buildReflUnfolder(ctx *unfoldCtx, t reflect.Type) (reflUnfolder, error) {
@@ -130,7 +137,7 @@ main: |
       return nil, errTODO()
 
     case reflect.Ptr:
-      unfolderElem, err := lookupReflUnfolder(ctx, bt)
+      unfolderElem, err := lookupReflUnfolder(ctx, bt, true)
       if err != nil {
         return nil, err
       }
@@ -138,6 +145,11 @@ main: |
 
     case reflect.Slice:
       et := bt.Elem()
+
+      if unfolderElem := lookupReflUser(ctx, et); unfolderElem != nil {
+        return newUnfolderReflSlice(unfolderElem), nil
+      }
+
       switch et.Kind() {
       case reflect.Interface:
         return unfolderReflArrIfc, nil
@@ -147,7 +159,7 @@ main: |
       {{ end }}
       }
 
-      unfolderElem, err := lookupReflUnfolder(ctx, reflect.PtrTo(et))
+      unfolderElem, err := lookupReflUnfolder(ctx, reflect.PtrTo(et), false)
       if err != nil {
         return nil, err
       }
@@ -155,6 +167,11 @@ main: |
 
     case reflect.Map:
       et := bt.Elem()
+
+      if unfolderElem := lookupReflUser(ctx, et); unfolderElem != nil {
+        return newUnfolderReflMap(unfolderElem), nil
+      }
+
       switch et.Kind() {
       case reflect.Interface:
         return unfolderReflMapIfc, nil
@@ -164,7 +181,7 @@ main: |
       {{ end }}
       }
 
-      unfolderElem, err := lookupReflUnfolder(ctx, reflect.PtrTo(et))
+      unfolderElem, err := lookupReflUnfolder(ctx, reflect.PtrTo(et), false)
       if err != nil {
         return nil, err
       }

--- a/gotype/unfold_lookup_go.yml
+++ b/gotype/unfold_lookup_go.yml
@@ -84,7 +84,13 @@ main: |
   }
 
   func lookupReflUnfolder(ctx *unfoldCtx, t reflect.Type) (reflUnfolder, error) {
-    if f := unfoldRegistry.find(t); f != nil {
+    if ctx.userReg != nil {
+      if f := ctx.userReg[t]; f != nil {
+        return f, nil
+      }
+    }
+
+    if f := ctx.reg.find(t); f != nil {
       return f, nil
     }
 
@@ -93,7 +99,7 @@ main: |
       return nil, err
     }
 
-    unfoldRegistry.set(t, f)
+    ctx.reg.set(t, f)
     return f, nil
   }
 

--- a/gotype/unfold_lookup_go.yml
+++ b/gotype/unfold_lookup_go.yml
@@ -21,6 +21,17 @@ import:
 main: |
   package gotype
 
+  func lookupUserPrimitiveConstructor(t reflect.Type) func(reflect.Value) ptrUnfolder {
+    switch t.Kind() {
+    {{- range data.primitiveTypes }}
+    case reflect.{{ capitalize . }}:
+      return {{ capitalize . | printf "newUserUnfolder%v" }}
+    {{ end }}
+    default:
+      return nil
+    }
+  }
+
   func lookupGoTypeUnfolder(to interface{}) (unsafe.Pointer, ptrUnfolder) {
     switch ptr := to.(type) {
       case *interface{}:

--- a/gotype/unfold_opts.go
+++ b/gotype/unfold_opts.go
@@ -38,7 +38,7 @@ func applyUnfoldOpts(opts []UnfoldOption) (i initUnfoldOptions, err error) {
 
 // Unfolders accepts a list of primitive or processing unfolders.
 //
-// Primitive must implement a function matching the type: func(to *Target, from P) error
+// Primitive unfolder must implement a function matching the type: func(to *Target, from P) error
 // Where to is an arbitrary go type that the result should be written to and
 // P must be one of: bool, string, uint(8|16|32|64), int(8|16|32|64), float(32|64)
 //

--- a/gotype/unfold_opts.go
+++ b/gotype/unfold_opts.go
@@ -1,0 +1,77 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gotype
+
+import (
+	"reflect"
+)
+
+type initUnfoldOptions struct {
+	unfoldFns map[reflect.Type]reflUnfolder
+}
+
+type UnfoldOption func(*initUnfoldOptions) error
+
+func applyUnfoldOpts(opts []UnfoldOption) (i initUnfoldOptions, err error) {
+	for _, o := range opts {
+		if err = o(&i); err != nil {
+			break
+		}
+	}
+	return i, err
+}
+
+// Unfolders accepts a list of primitive or structured unfolders.
+//
+// Primitive must implement a function matching the type: func(to *Target, from P) error
+// Where to is an arbitrary go type that the result should be written to and
+// P must be one of: bool, string, uint(8|16|32|64), int(8|16|32|64), float(32|64)
+//
+// Stuctured unfolders ... // TODO
+func Unfolders(in ...interface{}) UnfoldOption {
+	unfolders, err := makeUserUnfolderFns(in)
+	if err != nil || len(unfolders) == 0 {
+		return func(_ *initUnfoldOptions) error { return err }
+	}
+
+	return func(o *initUnfoldOptions) error {
+		if o.unfoldFns == nil {
+			o.unfoldFns = map[reflect.Type]reflUnfolder{}
+		}
+
+		for k, v := range unfolders {
+			o.unfoldFns[k] = v
+		}
+		return nil
+	}
+}
+
+func makeUserUnfolderFns(in []interface{}) (map[reflect.Type]reflUnfolder, error) {
+	M := map[reflect.Type]reflUnfolder{}
+
+	for _, cur := range in {
+		t, unfolder, err := makeUserUnfolder(reflect.ValueOf(cur))
+		if err != nil {
+			return nil, err
+		}
+
+		M[t] = unfolder
+	}
+
+	return M, nil
+}

--- a/gotype/unfold_struct.go
+++ b/gotype/unfold_struct.go
@@ -129,7 +129,7 @@ func makeFieldUnfolder(ctx *unfoldCtx, st reflect.StructField) (fieldUnfolder, e
 		fu.initState = pu.initState
 	} else {
 		targetType := reflect.PtrTo(st.Type)
-		ru, err := lookupReflUnfolder(ctx, targetType)
+		ru, err := lookupReflUnfolder(ctx, targetType, true)
 		if err != nil {
 			return fu, err
 		}

--- a/gotype/unfold_struct.go
+++ b/gotype/unfold_struct.go
@@ -124,12 +124,14 @@ func fieldUnfolders(ctx *unfoldCtx, t reflect.Type) (map[string]fieldUnfolder, e
 
 func makeFieldUnfolder(ctx *unfoldCtx, st reflect.StructField) (fieldUnfolder, error) {
 	fu := fieldUnfolder{offset: st.Offset}
+	targetType := reflect.PtrTo(st.Type)
 
-	if pu := lookupGoPtrUnfolder(st.Type); pu != nil {
+	if uu := lookupReflUser(ctx, targetType); uu != nil {
+		fu.initState = wrapReflUnfolder(st.Type, uu)
+	} else if pu := lookupGoPtrUnfolder(st.Type); pu != nil {
 		fu.initState = pu.initState
 	} else {
-		targetType := reflect.PtrTo(st.Type)
-		ru, err := lookupReflUnfolder(ctx, targetType, true)
+		ru, err := lookupReflUnfolder(ctx, targetType, false)
 		if err != nil {
 			return fu, err
 		}

--- a/gotype/unfold_test.go
+++ b/gotype/unfold_test.go
@@ -402,6 +402,18 @@ func TestUserUnfold(t *testing.T) {
 				return err
 			},
 		},
+		{
+			input: true,
+			want:  myint(1),
+			unfolder: func(to *myint, in bool) error {
+				if in {
+					*to = 1
+				} else {
+					*to = 0
+				}
+				return nil
+			},
+		},
 	}
 
 	for i, test := range tests {

--- a/gotype/unfold_test.go
+++ b/gotype/unfold_test.go
@@ -387,6 +387,56 @@ func unfoldSamples() map[string]unfoldCase {
 
 func TestUserUnfold(t *testing.T) {
 	type myint int
+	type addInt struct{ A, B int }
+
+	type complexUnfolder func(*myint, interface{}) error
+	type initUnfolder func(*myint) (interface{}, complexUnfolder)
+
+	unfoldFromString := func(to *myint, in string) error {
+		i, err := strconv.Atoi(in)
+		*to = myint(i)
+		return err
+	}
+
+	unfoldFromBool := func(to *myint, in bool) error {
+		*to = 0
+		if in {
+			*to = 1
+		}
+		return nil
+	}
+
+	makeCellUnfolder := func(cell interface{}, proc func(*myint)) initUnfolder {
+		return func(_ *myint) (interface{}, complexUnfolder) {
+			return cell, func(to *myint, _ interface{}) error {
+				proc(to)
+				return nil
+			}
+		}
+	}
+
+	makeUnfoldWithIntCell := func(extra int) initUnfolder {
+		cell := new(int)
+		return makeCellUnfolder(cell, func(to *myint) {
+			*to = myint(*cell + extra)
+		})
+	}
+
+	makeUnfoldReuseVar := func(extra int) initUnfolder {
+		return func(to *myint) (interface{}, complexUnfolder) {
+			return to, func(to *myint, _ interface{}) error {
+				*to += myint(extra)
+				return nil
+			}
+		}
+	}
+
+	makeUnfoldStructAdd := func() initUnfolder {
+		cell := &addInt{} // prealloc cell for reuse
+		return makeCellUnfolder(cell, func(to *myint) {
+			*to = myint(cell.A + cell.B)
+		})
+	}
 
 	tests := map[string]struct {
 		input    interface{}
@@ -394,106 +444,104 @@ func TestUserUnfold(t *testing.T) {
 		unfolder interface{}
 	}{
 		"parse from string": {
-			input: "12345",
-			want:  myint(12345),
-			unfolder: func(to *myint, in string) error {
-				i, err := strconv.Atoi(in)
-				*to = myint(i)
-				return err
-			},
+			input:    "12345",
+			want:     myint(12345),
+			unfolder: unfoldFromString,
 		},
 		"parse from bool": {
-			input: true,
-			want:  myint(1),
-			unfolder: func(to *myint, in bool) error {
-				if in {
-					*to = 1
-				} else {
-					*to = 0
-				}
-				return nil
-			},
+			input:    true,
+			want:     myint(1),
+			unfolder: unfoldFromBool,
 		},
 		"custom post processing with temporary cell": {
-			input: 23,
-			want:  myint(23),
-			unfolder: func(to *myint) (interface{}, func(*myint, interface{}) error) {
-				return new(int), func(to *myint, tmp interface{}) error {
-					parsed := *(tmp.(*int))
-					*to = myint(parsed)
-					return nil
-				}
-			},
-		},
-		"reuse cell in id post processor": {
-			input: 23,
-			want:  myint(23),
-			unfolder: func(to *myint) (interface{}, func(*myint, interface{}) error) {
-				return to, func(to *myint, tmp interface{}) error {
-					return nil
-				}
-			},
+			input:    3,
+			want:     myint(23),
+			unfolder: makeUnfoldWithIntCell(20),
 		},
 		"reuse cell and post process": {
-			input: 23,
-			want:  myint(42),
-			unfolder: func(to *myint) (interface{}, func(*myint, interface{}) error) {
-				return to, func(to *myint, tmp interface{}) error {
-					*to += 19
-					return nil
-				}
-			},
-		},
-		"parse array values from strings": {
-			input: []string{"1", "2", "3"},
-			want:  []myint{1, 2, 3},
-			unfolder: func(to *myint, in string) error {
-				i, err := strconv.Atoi(in)
-				*to = myint(i)
-				return err
-			},
-		},
-		"array with post processing and temporary cell": {
-			input: []int{1, 2, 3},
-			want:  []myint{21, 22, 23},
-			unfolder: func(to *myint) (interface{}, func(*myint, interface{}) error) {
-				return new(int), func(to *myint, tmp interface{}) error {
-					parsed := *(tmp.(*int))
-					*to = myint(parsed + 20)
-					return nil
-				}
-			},
-		},
-		"array post processing with cell reuse": {
-			input: []int{1, 2, 3},
-			want:  []myint{21, 22, 23},
-			unfolder: func(to *myint) (interface{}, func(*myint, interface{}) error) {
-				return to, func(to *myint, _ interface{}) error {
-					*to += 20
-					return nil
-				}
-			},
+			input:    13,
+			want:     myint(23),
+			unfolder: makeUnfoldReuseVar(10),
 		},
 		"value from custom structure": {
-			input: map[string]int{"a": 1, "b": 2},
-			want:  myint(3),
-			unfolder: func(to *myint) (interface{}, func(*myint, interface{}) error) {
-				cell := &struct{ A, B int }{}
-				return cell, func(to *myint, _ interface{}) error {
-					*to = myint(cell.A + cell.B)
-					return nil
-				}
-			},
+			input:    addInt{1, 2},
+			want:     myint(3),
+			unfolder: makeUnfoldStructAdd(),
+		},
+		"parse array values from strings": {
+			input:    []string{"1", "2", "3"},
+			want:     []myint{1, 2, 3},
+			unfolder: unfoldFromString,
+		},
+		"array with temporary cell": {
+			input:    []int{1, 2, 3},
+			want:     []myint{21, 22, 23},
+			unfolder: makeUnfoldWithIntCell(20),
+		},
+		"array post processing with cell reuse": {
+			input:    []int{1, 2, 3},
+			want:     []myint{11, 12, 13},
+			unfolder: makeUnfoldReuseVar(10),
+		},
+		"array with values from custom structure": {
+			input:    []addInt{{1, 2}, {20, 3}},
+			want:     []myint{3, 23},
+			unfolder: makeUnfoldStructAdd(),
+		},
+		"parse map values from strings": {
+			input:    map[string]string{"a": "1", "b": "2", "c": "3"},
+			want:     map[string]myint{"a": 1, "b": 2, "c": 3},
+			unfolder: unfoldFromString,
+		},
+		"map with temporary cell": {
+			input:    map[string]int{"a": 1, "b": 2, "c": 3},
+			want:     map[string]myint{"a": 21, "b": 22, "c": 23},
+			unfolder: makeUnfoldWithIntCell(20),
+		},
+		"map post processing with cell reuse": {
+			input:    map[string]int{"a": 1, "b": 2, "c": 3},
+			want:     map[string]myint{"a": 21, "b": 22, "c": 23},
+			unfolder: makeUnfoldReuseVar(20),
+		},
+		"map with values from custom structure": {
+			input:    map[string]addInt{"a": {1, 2}, "b": {20, 3}},
+			want:     map[string]myint{"a": 3, "b": 23},
+			unfolder: makeUnfoldStructAdd(),
+		},
+		"struct field from string": {
+			input:    map[string]string{"a": "1"},
+			want:     struct{ A myint }{1},
+			unfolder: unfoldFromString,
+		},
+		"struct field with temporary cell": {
+			input:    map[string]int{"a": 1},
+			want:     struct{ A myint }{11},
+			unfolder: makeUnfoldWithIntCell(10),
+		},
+		"struct field reuse and post process": {
+			input:    map[string]int{"a": 1},
+			want:     struct{ A myint }{11},
+			unfolder: makeUnfoldReuseVar(10),
+		},
+		"struct field with custom structure": {
+			input:    map[string]addInt{"a": {1, 2}},
+			want:     struct{ A myint }{3},
+			unfolder: makeUnfoldStructAdd(),
 		},
 	}
 
 	for title, test := range tests {
-		test := test
 		t.Run(title, func(t *testing.T) {
-			t.Parallel()
-
+			var cell reflect.Value
 			wantType := reflect.TypeOf(test.want)
-			cell := reflect.New(wantType)
+
+			if wantType.Kind() == reflect.Map {
+				tmp := reflect.MakeMap(wantType)
+				cell = reflect.New(wantType)
+				cell.Elem().Set(tmp)
+			} else {
+				cell = reflect.New(wantType)
+			}
 
 			u, err := NewUnfolder(cell.Interface(), Unfolders(test.unfolder))
 			if err != nil {

--- a/gotype/unfold_user.go
+++ b/gotype/unfold_user.go
@@ -1,0 +1,83 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gotype
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+func makeUserUnfolder(fn reflect.Value) (target reflect.Type, unfolder reflUnfolder, err error) {
+	t := fn.Type()
+
+	if fn.Kind() != reflect.Func {
+		return nil, nil, errors.New("function type required")
+	}
+
+	switch {
+	case t.NumIn() == 2 && t.NumOut() == 1:
+		unfolder, err = makeUserPrimitiveUnfolder(fn)
+	case t.NumIn() == 1 && t.NumOut() == 2:
+		unfolder, err = makeUserStructUnfolder(fn)
+	default:
+		return nil, nil, fmt.Errorf("invalid number of arguments in unfolder: %v", fn)
+	}
+
+	return t.In(0), unfolder, err
+}
+
+func makeUserStructUnfolder(fn reflect.Value) (reflUnfolder, error) {
+	return nil, errors.New("TODO: add support for user defined structured unfolder")
+}
+
+func makeUserPrimitiveUnfolder(fn reflect.Value) (reflUnfolder, error) {
+	t := fn.Type()
+
+	if fn.Kind() != reflect.Func {
+		return nil, errors.New("function type required")
+	}
+
+	if t.NumIn() != 2 {
+		return nil, fmt.Errorf("function '%v' must accept 2 arguments", t.Name())
+	}
+	if t.NumOut() != 1 || t.Out(0) != tError {
+		return nil, fmt.Errorf("function '%v' does not return errors", t.Name())
+	}
+
+	ta0 := t.In(0)
+	if ta0.Kind() != reflect.Ptr {
+		return nil, fmt.Errorf("first argument in function '%v' must be a pointer", t.Name())
+	}
+
+	constr := lookupUserPrimitiveConstructor(t.In(1))
+	if constr == nil {
+		return nil, fmt.Errorf("%v is no supported primitive type", t.In(1))
+	}
+
+	unfolder := constr(fn)
+	return liftGoUnfolder(unfolder), nil
+}
+
+func lookupUserPrimitiveConstructor(t reflect.Type) func(reflect.Value) ptrUnfolder {
+	if t.Kind() != reflect.String {
+		return nil
+	}
+
+	return newUserUnfolderString
+}

--- a/gotype/unfold_user.go
+++ b/gotype/unfold_user.go
@@ -73,11 +73,3 @@ func makeUserPrimitiveUnfolder(fn reflect.Value) (reflUnfolder, error) {
 	unfolder := constr(fn)
 	return liftGoUnfolder(unfolder), nil
 }
-
-func lookupUserPrimitiveConstructor(t reflect.Type) func(reflect.Value) ptrUnfolder {
-	if t.Kind() != reflect.String {
-		return nil
-	}
-
-	return newUserUnfolderString
-}

--- a/gotype/unfold_user_primitive.generated.go
+++ b/gotype/unfold_user_primitive.generated.go
@@ -1,0 +1,1147 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This file has been generated from 'unfold_user_primitive.yml', do not edit
+package gotype
+
+import (
+	"reflect"
+	"unsafe"
+
+	stunsafe "github.com/elastic/go-structform/internal/unsafe"
+)
+
+type (
+	userUnfolderBool struct {
+		unfolderErrUnknown
+		fn userUnfolderBoolCB
+	}
+
+	userUnfolderBoolCB func(unsafe.Pointer, bool) error
+)
+
+func newUserUnfolderBool(fn reflect.Value) ptrUnfolder {
+	return &userUnfolderBool{
+		fn: *((*userUnfolderBoolCB)(stunsafe.UnsafeFnPtr(fn))),
+	}
+}
+
+func (u *userUnfolderBool) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+	ctx.unfolder.push(u)
+	ctx.ptr.push(ptr)
+}
+
+func (u *userUnfolderBool) cleanup(ctx *unfoldCtx) {
+	ctx.unfolder.pop()
+	ctx.ptr.pop()
+}
+
+func (u *userUnfolderBool) process(ctx *unfoldCtx, v bool) error {
+	err := u.fn(ctx.ptr.current, v)
+	u.cleanup(ctx)
+	return err
+}
+
+type (
+	userUnfolderString struct {
+		unfolderErrUnknown
+		fn userUnfolderStringCB
+	}
+
+	userUnfolderStringCB func(unsafe.Pointer, string) error
+)
+
+func newUserUnfolderString(fn reflect.Value) ptrUnfolder {
+	return &userUnfolderString{
+		fn: *((*userUnfolderStringCB)(stunsafe.UnsafeFnPtr(fn))),
+	}
+}
+
+func (u *userUnfolderString) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+	ctx.unfolder.push(u)
+	ctx.ptr.push(ptr)
+}
+
+func (u *userUnfolderString) cleanup(ctx *unfoldCtx) {
+	ctx.unfolder.pop()
+	ctx.ptr.pop()
+}
+
+func (u *userUnfolderString) process(ctx *unfoldCtx, v string) error {
+	err := u.fn(ctx.ptr.current, v)
+	u.cleanup(ctx)
+	return err
+}
+
+type (
+	userUnfolderUint struct {
+		unfolderErrUnknown
+		fn userUnfolderUintCB
+	}
+
+	userUnfolderUintCB func(unsafe.Pointer, uint) error
+)
+
+func newUserUnfolderUint(fn reflect.Value) ptrUnfolder {
+	return &userUnfolderUint{
+		fn: *((*userUnfolderUintCB)(stunsafe.UnsafeFnPtr(fn))),
+	}
+}
+
+func (u *userUnfolderUint) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+	ctx.unfolder.push(u)
+	ctx.ptr.push(ptr)
+}
+
+func (u *userUnfolderUint) cleanup(ctx *unfoldCtx) {
+	ctx.unfolder.pop()
+	ctx.ptr.pop()
+}
+
+func (u *userUnfolderUint) process(ctx *unfoldCtx, v uint) error {
+	err := u.fn(ctx.ptr.current, v)
+	u.cleanup(ctx)
+	return err
+}
+
+type (
+	userUnfolderUint8 struct {
+		unfolderErrUnknown
+		fn userUnfolderUint8CB
+	}
+
+	userUnfolderUint8CB func(unsafe.Pointer, uint8) error
+)
+
+func newUserUnfolderUint8(fn reflect.Value) ptrUnfolder {
+	return &userUnfolderUint8{
+		fn: *((*userUnfolderUint8CB)(stunsafe.UnsafeFnPtr(fn))),
+	}
+}
+
+func (u *userUnfolderUint8) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+	ctx.unfolder.push(u)
+	ctx.ptr.push(ptr)
+}
+
+func (u *userUnfolderUint8) cleanup(ctx *unfoldCtx) {
+	ctx.unfolder.pop()
+	ctx.ptr.pop()
+}
+
+func (u *userUnfolderUint8) process(ctx *unfoldCtx, v uint8) error {
+	err := u.fn(ctx.ptr.current, v)
+	u.cleanup(ctx)
+	return err
+}
+
+type (
+	userUnfolderUint16 struct {
+		unfolderErrUnknown
+		fn userUnfolderUint16CB
+	}
+
+	userUnfolderUint16CB func(unsafe.Pointer, uint16) error
+)
+
+func newUserUnfolderUint16(fn reflect.Value) ptrUnfolder {
+	return &userUnfolderUint16{
+		fn: *((*userUnfolderUint16CB)(stunsafe.UnsafeFnPtr(fn))),
+	}
+}
+
+func (u *userUnfolderUint16) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+	ctx.unfolder.push(u)
+	ctx.ptr.push(ptr)
+}
+
+func (u *userUnfolderUint16) cleanup(ctx *unfoldCtx) {
+	ctx.unfolder.pop()
+	ctx.ptr.pop()
+}
+
+func (u *userUnfolderUint16) process(ctx *unfoldCtx, v uint16) error {
+	err := u.fn(ctx.ptr.current, v)
+	u.cleanup(ctx)
+	return err
+}
+
+type (
+	userUnfolderUint32 struct {
+		unfolderErrUnknown
+		fn userUnfolderUint32CB
+	}
+
+	userUnfolderUint32CB func(unsafe.Pointer, uint32) error
+)
+
+func newUserUnfolderUint32(fn reflect.Value) ptrUnfolder {
+	return &userUnfolderUint32{
+		fn: *((*userUnfolderUint32CB)(stunsafe.UnsafeFnPtr(fn))),
+	}
+}
+
+func (u *userUnfolderUint32) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+	ctx.unfolder.push(u)
+	ctx.ptr.push(ptr)
+}
+
+func (u *userUnfolderUint32) cleanup(ctx *unfoldCtx) {
+	ctx.unfolder.pop()
+	ctx.ptr.pop()
+}
+
+func (u *userUnfolderUint32) process(ctx *unfoldCtx, v uint32) error {
+	err := u.fn(ctx.ptr.current, v)
+	u.cleanup(ctx)
+	return err
+}
+
+type (
+	userUnfolderUint64 struct {
+		unfolderErrUnknown
+		fn userUnfolderUint64CB
+	}
+
+	userUnfolderUint64CB func(unsafe.Pointer, uint64) error
+)
+
+func newUserUnfolderUint64(fn reflect.Value) ptrUnfolder {
+	return &userUnfolderUint64{
+		fn: *((*userUnfolderUint64CB)(stunsafe.UnsafeFnPtr(fn))),
+	}
+}
+
+func (u *userUnfolderUint64) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+	ctx.unfolder.push(u)
+	ctx.ptr.push(ptr)
+}
+
+func (u *userUnfolderUint64) cleanup(ctx *unfoldCtx) {
+	ctx.unfolder.pop()
+	ctx.ptr.pop()
+}
+
+func (u *userUnfolderUint64) process(ctx *unfoldCtx, v uint64) error {
+	err := u.fn(ctx.ptr.current, v)
+	u.cleanup(ctx)
+	return err
+}
+
+type (
+	userUnfolderInt struct {
+		unfolderErrUnknown
+		fn userUnfolderIntCB
+	}
+
+	userUnfolderIntCB func(unsafe.Pointer, int) error
+)
+
+func newUserUnfolderInt(fn reflect.Value) ptrUnfolder {
+	return &userUnfolderInt{
+		fn: *((*userUnfolderIntCB)(stunsafe.UnsafeFnPtr(fn))),
+	}
+}
+
+func (u *userUnfolderInt) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+	ctx.unfolder.push(u)
+	ctx.ptr.push(ptr)
+}
+
+func (u *userUnfolderInt) cleanup(ctx *unfoldCtx) {
+	ctx.unfolder.pop()
+	ctx.ptr.pop()
+}
+
+func (u *userUnfolderInt) process(ctx *unfoldCtx, v int) error {
+	err := u.fn(ctx.ptr.current, v)
+	u.cleanup(ctx)
+	return err
+}
+
+type (
+	userUnfolderInt8 struct {
+		unfolderErrUnknown
+		fn userUnfolderInt8CB
+	}
+
+	userUnfolderInt8CB func(unsafe.Pointer, int8) error
+)
+
+func newUserUnfolderInt8(fn reflect.Value) ptrUnfolder {
+	return &userUnfolderInt8{
+		fn: *((*userUnfolderInt8CB)(stunsafe.UnsafeFnPtr(fn))),
+	}
+}
+
+func (u *userUnfolderInt8) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+	ctx.unfolder.push(u)
+	ctx.ptr.push(ptr)
+}
+
+func (u *userUnfolderInt8) cleanup(ctx *unfoldCtx) {
+	ctx.unfolder.pop()
+	ctx.ptr.pop()
+}
+
+func (u *userUnfolderInt8) process(ctx *unfoldCtx, v int8) error {
+	err := u.fn(ctx.ptr.current, v)
+	u.cleanup(ctx)
+	return err
+}
+
+type (
+	userUnfolderInt16 struct {
+		unfolderErrUnknown
+		fn userUnfolderInt16CB
+	}
+
+	userUnfolderInt16CB func(unsafe.Pointer, int16) error
+)
+
+func newUserUnfolderInt16(fn reflect.Value) ptrUnfolder {
+	return &userUnfolderInt16{
+		fn: *((*userUnfolderInt16CB)(stunsafe.UnsafeFnPtr(fn))),
+	}
+}
+
+func (u *userUnfolderInt16) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+	ctx.unfolder.push(u)
+	ctx.ptr.push(ptr)
+}
+
+func (u *userUnfolderInt16) cleanup(ctx *unfoldCtx) {
+	ctx.unfolder.pop()
+	ctx.ptr.pop()
+}
+
+func (u *userUnfolderInt16) process(ctx *unfoldCtx, v int16) error {
+	err := u.fn(ctx.ptr.current, v)
+	u.cleanup(ctx)
+	return err
+}
+
+type (
+	userUnfolderInt32 struct {
+		unfolderErrUnknown
+		fn userUnfolderInt32CB
+	}
+
+	userUnfolderInt32CB func(unsafe.Pointer, int32) error
+)
+
+func newUserUnfolderInt32(fn reflect.Value) ptrUnfolder {
+	return &userUnfolderInt32{
+		fn: *((*userUnfolderInt32CB)(stunsafe.UnsafeFnPtr(fn))),
+	}
+}
+
+func (u *userUnfolderInt32) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+	ctx.unfolder.push(u)
+	ctx.ptr.push(ptr)
+}
+
+func (u *userUnfolderInt32) cleanup(ctx *unfoldCtx) {
+	ctx.unfolder.pop()
+	ctx.ptr.pop()
+}
+
+func (u *userUnfolderInt32) process(ctx *unfoldCtx, v int32) error {
+	err := u.fn(ctx.ptr.current, v)
+	u.cleanup(ctx)
+	return err
+}
+
+type (
+	userUnfolderInt64 struct {
+		unfolderErrUnknown
+		fn userUnfolderInt64CB
+	}
+
+	userUnfolderInt64CB func(unsafe.Pointer, int64) error
+)
+
+func newUserUnfolderInt64(fn reflect.Value) ptrUnfolder {
+	return &userUnfolderInt64{
+		fn: *((*userUnfolderInt64CB)(stunsafe.UnsafeFnPtr(fn))),
+	}
+}
+
+func (u *userUnfolderInt64) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+	ctx.unfolder.push(u)
+	ctx.ptr.push(ptr)
+}
+
+func (u *userUnfolderInt64) cleanup(ctx *unfoldCtx) {
+	ctx.unfolder.pop()
+	ctx.ptr.pop()
+}
+
+func (u *userUnfolderInt64) process(ctx *unfoldCtx, v int64) error {
+	err := u.fn(ctx.ptr.current, v)
+	u.cleanup(ctx)
+	return err
+}
+
+type (
+	userUnfolderFloat32 struct {
+		unfolderErrUnknown
+		fn userUnfolderFloat32CB
+	}
+
+	userUnfolderFloat32CB func(unsafe.Pointer, float32) error
+)
+
+func newUserUnfolderFloat32(fn reflect.Value) ptrUnfolder {
+	return &userUnfolderFloat32{
+		fn: *((*userUnfolderFloat32CB)(stunsafe.UnsafeFnPtr(fn))),
+	}
+}
+
+func (u *userUnfolderFloat32) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+	ctx.unfolder.push(u)
+	ctx.ptr.push(ptr)
+}
+
+func (u *userUnfolderFloat32) cleanup(ctx *unfoldCtx) {
+	ctx.unfolder.pop()
+	ctx.ptr.pop()
+}
+
+func (u *userUnfolderFloat32) process(ctx *unfoldCtx, v float32) error {
+	err := u.fn(ctx.ptr.current, v)
+	u.cleanup(ctx)
+	return err
+}
+
+type (
+	userUnfolderFloat64 struct {
+		unfolderErrUnknown
+		fn userUnfolderFloat64CB
+	}
+
+	userUnfolderFloat64CB func(unsafe.Pointer, float64) error
+)
+
+func newUserUnfolderFloat64(fn reflect.Value) ptrUnfolder {
+	return &userUnfolderFloat64{
+		fn: *((*userUnfolderFloat64CB)(stunsafe.UnsafeFnPtr(fn))),
+	}
+}
+
+func (u *userUnfolderFloat64) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+	ctx.unfolder.push(u)
+	ctx.ptr.push(ptr)
+}
+
+func (u *userUnfolderFloat64) cleanup(ctx *unfoldCtx) {
+	ctx.unfolder.pop()
+	ctx.ptr.pop()
+}
+
+func (u *userUnfolderFloat64) process(ctx *unfoldCtx, v float64) error {
+	err := u.fn(ctx.ptr.current, v)
+	u.cleanup(ctx)
+	return err
+}
+
+func (u *userUnfolderBool) OnNil(ctx *unfoldCtx) error {
+	return u.process(ctx, false)
+}
+
+func (u *userUnfolderBool) OnBool(ctx *unfoldCtx, v bool) error { return u.process(ctx, v) }
+
+func (u *userUnfolderString) OnNil(ctx *unfoldCtx) error {
+	return u.process(ctx, "")
+}
+
+func (u *userUnfolderString) OnString(ctx *unfoldCtx, v string) error { return u.process(ctx, v) }
+func (u *userUnfolderString) OnStringRef(ctx *unfoldCtx, v []byte) error {
+	return u.OnString(ctx, string(v))
+}
+
+func (u *userUnfolderUint) OnNil(ctx *unfoldCtx) error {
+	return u.process(ctx, 0)
+}
+
+func (u *userUnfolderUint) OnByte(ctx *unfoldCtx, v byte) error {
+	return u.process(ctx, uint(v))
+}
+
+func (u *userUnfolderUint) OnUint(ctx *unfoldCtx, v uint) error {
+	return u.process(ctx, uint(v))
+}
+
+func (u *userUnfolderUint) OnUint8(ctx *unfoldCtx, v uint8) error {
+	return u.process(ctx, uint(v))
+}
+
+func (u *userUnfolderUint) OnUint16(ctx *unfoldCtx, v uint16) error {
+	return u.process(ctx, uint(v))
+}
+
+func (u *userUnfolderUint) OnUint32(ctx *unfoldCtx, v uint32) error {
+	return u.process(ctx, uint(v))
+}
+
+func (u *userUnfolderUint) OnUint64(ctx *unfoldCtx, v uint64) error {
+	return u.process(ctx, uint(v))
+}
+
+func (u *userUnfolderUint) OnInt(ctx *unfoldCtx, v int) error {
+	return u.process(ctx, uint(v))
+}
+
+func (u *userUnfolderUint) OnInt8(ctx *unfoldCtx, v int8) error {
+	return u.process(ctx, uint(v))
+}
+
+func (u *userUnfolderUint) OnInt16(ctx *unfoldCtx, v int16) error {
+	return u.process(ctx, uint(v))
+}
+
+func (u *userUnfolderUint) OnInt32(ctx *unfoldCtx, v int32) error {
+	return u.process(ctx, uint(v))
+}
+
+func (u *userUnfolderUint) OnInt64(ctx *unfoldCtx, v int64) error {
+	return u.process(ctx, uint(v))
+}
+
+func (u *userUnfolderUint) OnFloat32(ctx *unfoldCtx, v float32) error {
+	return u.process(ctx, uint(v))
+}
+
+func (u *userUnfolderUint) OnFloat64(ctx *unfoldCtx, v float64) error {
+	return u.process(ctx, uint(v))
+}
+
+func (u *userUnfolderUint8) OnNil(ctx *unfoldCtx) error {
+	return u.process(ctx, 0)
+}
+
+func (u *userUnfolderUint8) OnByte(ctx *unfoldCtx, v byte) error {
+	return u.process(ctx, uint8(v))
+}
+
+func (u *userUnfolderUint8) OnUint(ctx *unfoldCtx, v uint) error {
+	return u.process(ctx, uint8(v))
+}
+
+func (u *userUnfolderUint8) OnUint8(ctx *unfoldCtx, v uint8) error {
+	return u.process(ctx, uint8(v))
+}
+
+func (u *userUnfolderUint8) OnUint16(ctx *unfoldCtx, v uint16) error {
+	return u.process(ctx, uint8(v))
+}
+
+func (u *userUnfolderUint8) OnUint32(ctx *unfoldCtx, v uint32) error {
+	return u.process(ctx, uint8(v))
+}
+
+func (u *userUnfolderUint8) OnUint64(ctx *unfoldCtx, v uint64) error {
+	return u.process(ctx, uint8(v))
+}
+
+func (u *userUnfolderUint8) OnInt(ctx *unfoldCtx, v int) error {
+	return u.process(ctx, uint8(v))
+}
+
+func (u *userUnfolderUint8) OnInt8(ctx *unfoldCtx, v int8) error {
+	return u.process(ctx, uint8(v))
+}
+
+func (u *userUnfolderUint8) OnInt16(ctx *unfoldCtx, v int16) error {
+	return u.process(ctx, uint8(v))
+}
+
+func (u *userUnfolderUint8) OnInt32(ctx *unfoldCtx, v int32) error {
+	return u.process(ctx, uint8(v))
+}
+
+func (u *userUnfolderUint8) OnInt64(ctx *unfoldCtx, v int64) error {
+	return u.process(ctx, uint8(v))
+}
+
+func (u *userUnfolderUint8) OnFloat32(ctx *unfoldCtx, v float32) error {
+	return u.process(ctx, uint8(v))
+}
+
+func (u *userUnfolderUint8) OnFloat64(ctx *unfoldCtx, v float64) error {
+	return u.process(ctx, uint8(v))
+}
+
+func (u *userUnfolderUint16) OnNil(ctx *unfoldCtx) error {
+	return u.process(ctx, 0)
+}
+
+func (u *userUnfolderUint16) OnByte(ctx *unfoldCtx, v byte) error {
+	return u.process(ctx, uint16(v))
+}
+
+func (u *userUnfolderUint16) OnUint(ctx *unfoldCtx, v uint) error {
+	return u.process(ctx, uint16(v))
+}
+
+func (u *userUnfolderUint16) OnUint8(ctx *unfoldCtx, v uint8) error {
+	return u.process(ctx, uint16(v))
+}
+
+func (u *userUnfolderUint16) OnUint16(ctx *unfoldCtx, v uint16) error {
+	return u.process(ctx, uint16(v))
+}
+
+func (u *userUnfolderUint16) OnUint32(ctx *unfoldCtx, v uint32) error {
+	return u.process(ctx, uint16(v))
+}
+
+func (u *userUnfolderUint16) OnUint64(ctx *unfoldCtx, v uint64) error {
+	return u.process(ctx, uint16(v))
+}
+
+func (u *userUnfolderUint16) OnInt(ctx *unfoldCtx, v int) error {
+	return u.process(ctx, uint16(v))
+}
+
+func (u *userUnfolderUint16) OnInt8(ctx *unfoldCtx, v int8) error {
+	return u.process(ctx, uint16(v))
+}
+
+func (u *userUnfolderUint16) OnInt16(ctx *unfoldCtx, v int16) error {
+	return u.process(ctx, uint16(v))
+}
+
+func (u *userUnfolderUint16) OnInt32(ctx *unfoldCtx, v int32) error {
+	return u.process(ctx, uint16(v))
+}
+
+func (u *userUnfolderUint16) OnInt64(ctx *unfoldCtx, v int64) error {
+	return u.process(ctx, uint16(v))
+}
+
+func (u *userUnfolderUint16) OnFloat32(ctx *unfoldCtx, v float32) error {
+	return u.process(ctx, uint16(v))
+}
+
+func (u *userUnfolderUint16) OnFloat64(ctx *unfoldCtx, v float64) error {
+	return u.process(ctx, uint16(v))
+}
+
+func (u *userUnfolderUint32) OnNil(ctx *unfoldCtx) error {
+	return u.process(ctx, 0)
+}
+
+func (u *userUnfolderUint32) OnByte(ctx *unfoldCtx, v byte) error {
+	return u.process(ctx, uint32(v))
+}
+
+func (u *userUnfolderUint32) OnUint(ctx *unfoldCtx, v uint) error {
+	return u.process(ctx, uint32(v))
+}
+
+func (u *userUnfolderUint32) OnUint8(ctx *unfoldCtx, v uint8) error {
+	return u.process(ctx, uint32(v))
+}
+
+func (u *userUnfolderUint32) OnUint16(ctx *unfoldCtx, v uint16) error {
+	return u.process(ctx, uint32(v))
+}
+
+func (u *userUnfolderUint32) OnUint32(ctx *unfoldCtx, v uint32) error {
+	return u.process(ctx, uint32(v))
+}
+
+func (u *userUnfolderUint32) OnUint64(ctx *unfoldCtx, v uint64) error {
+	return u.process(ctx, uint32(v))
+}
+
+func (u *userUnfolderUint32) OnInt(ctx *unfoldCtx, v int) error {
+	return u.process(ctx, uint32(v))
+}
+
+func (u *userUnfolderUint32) OnInt8(ctx *unfoldCtx, v int8) error {
+	return u.process(ctx, uint32(v))
+}
+
+func (u *userUnfolderUint32) OnInt16(ctx *unfoldCtx, v int16) error {
+	return u.process(ctx, uint32(v))
+}
+
+func (u *userUnfolderUint32) OnInt32(ctx *unfoldCtx, v int32) error {
+	return u.process(ctx, uint32(v))
+}
+
+func (u *userUnfolderUint32) OnInt64(ctx *unfoldCtx, v int64) error {
+	return u.process(ctx, uint32(v))
+}
+
+func (u *userUnfolderUint32) OnFloat32(ctx *unfoldCtx, v float32) error {
+	return u.process(ctx, uint32(v))
+}
+
+func (u *userUnfolderUint32) OnFloat64(ctx *unfoldCtx, v float64) error {
+	return u.process(ctx, uint32(v))
+}
+
+func (u *userUnfolderUint64) OnNil(ctx *unfoldCtx) error {
+	return u.process(ctx, 0)
+}
+
+func (u *userUnfolderUint64) OnByte(ctx *unfoldCtx, v byte) error {
+	return u.process(ctx, uint64(v))
+}
+
+func (u *userUnfolderUint64) OnUint(ctx *unfoldCtx, v uint) error {
+	return u.process(ctx, uint64(v))
+}
+
+func (u *userUnfolderUint64) OnUint8(ctx *unfoldCtx, v uint8) error {
+	return u.process(ctx, uint64(v))
+}
+
+func (u *userUnfolderUint64) OnUint16(ctx *unfoldCtx, v uint16) error {
+	return u.process(ctx, uint64(v))
+}
+
+func (u *userUnfolderUint64) OnUint32(ctx *unfoldCtx, v uint32) error {
+	return u.process(ctx, uint64(v))
+}
+
+func (u *userUnfolderUint64) OnUint64(ctx *unfoldCtx, v uint64) error {
+	return u.process(ctx, uint64(v))
+}
+
+func (u *userUnfolderUint64) OnInt(ctx *unfoldCtx, v int) error {
+	return u.process(ctx, uint64(v))
+}
+
+func (u *userUnfolderUint64) OnInt8(ctx *unfoldCtx, v int8) error {
+	return u.process(ctx, uint64(v))
+}
+
+func (u *userUnfolderUint64) OnInt16(ctx *unfoldCtx, v int16) error {
+	return u.process(ctx, uint64(v))
+}
+
+func (u *userUnfolderUint64) OnInt32(ctx *unfoldCtx, v int32) error {
+	return u.process(ctx, uint64(v))
+}
+
+func (u *userUnfolderUint64) OnInt64(ctx *unfoldCtx, v int64) error {
+	return u.process(ctx, uint64(v))
+}
+
+func (u *userUnfolderUint64) OnFloat32(ctx *unfoldCtx, v float32) error {
+	return u.process(ctx, uint64(v))
+}
+
+func (u *userUnfolderUint64) OnFloat64(ctx *unfoldCtx, v float64) error {
+	return u.process(ctx, uint64(v))
+}
+
+func (u *userUnfolderInt) OnNil(ctx *unfoldCtx) error {
+	return u.process(ctx, 0)
+}
+
+func (u *userUnfolderInt) OnByte(ctx *unfoldCtx, v byte) error {
+	return u.process(ctx, int(v))
+}
+
+func (u *userUnfolderInt) OnUint(ctx *unfoldCtx, v uint) error {
+	return u.process(ctx, int(v))
+}
+
+func (u *userUnfolderInt) OnUint8(ctx *unfoldCtx, v uint8) error {
+	return u.process(ctx, int(v))
+}
+
+func (u *userUnfolderInt) OnUint16(ctx *unfoldCtx, v uint16) error {
+	return u.process(ctx, int(v))
+}
+
+func (u *userUnfolderInt) OnUint32(ctx *unfoldCtx, v uint32) error {
+	return u.process(ctx, int(v))
+}
+
+func (u *userUnfolderInt) OnUint64(ctx *unfoldCtx, v uint64) error {
+	return u.process(ctx, int(v))
+}
+
+func (u *userUnfolderInt) OnInt(ctx *unfoldCtx, v int) error {
+	return u.process(ctx, int(v))
+}
+
+func (u *userUnfolderInt) OnInt8(ctx *unfoldCtx, v int8) error {
+	return u.process(ctx, int(v))
+}
+
+func (u *userUnfolderInt) OnInt16(ctx *unfoldCtx, v int16) error {
+	return u.process(ctx, int(v))
+}
+
+func (u *userUnfolderInt) OnInt32(ctx *unfoldCtx, v int32) error {
+	return u.process(ctx, int(v))
+}
+
+func (u *userUnfolderInt) OnInt64(ctx *unfoldCtx, v int64) error {
+	return u.process(ctx, int(v))
+}
+
+func (u *userUnfolderInt) OnFloat32(ctx *unfoldCtx, v float32) error {
+	return u.process(ctx, int(v))
+}
+
+func (u *userUnfolderInt) OnFloat64(ctx *unfoldCtx, v float64) error {
+	return u.process(ctx, int(v))
+}
+
+func (u *userUnfolderInt8) OnNil(ctx *unfoldCtx) error {
+	return u.process(ctx, 0)
+}
+
+func (u *userUnfolderInt8) OnByte(ctx *unfoldCtx, v byte) error {
+	return u.process(ctx, int8(v))
+}
+
+func (u *userUnfolderInt8) OnUint(ctx *unfoldCtx, v uint) error {
+	return u.process(ctx, int8(v))
+}
+
+func (u *userUnfolderInt8) OnUint8(ctx *unfoldCtx, v uint8) error {
+	return u.process(ctx, int8(v))
+}
+
+func (u *userUnfolderInt8) OnUint16(ctx *unfoldCtx, v uint16) error {
+	return u.process(ctx, int8(v))
+}
+
+func (u *userUnfolderInt8) OnUint32(ctx *unfoldCtx, v uint32) error {
+	return u.process(ctx, int8(v))
+}
+
+func (u *userUnfolderInt8) OnUint64(ctx *unfoldCtx, v uint64) error {
+	return u.process(ctx, int8(v))
+}
+
+func (u *userUnfolderInt8) OnInt(ctx *unfoldCtx, v int) error {
+	return u.process(ctx, int8(v))
+}
+
+func (u *userUnfolderInt8) OnInt8(ctx *unfoldCtx, v int8) error {
+	return u.process(ctx, int8(v))
+}
+
+func (u *userUnfolderInt8) OnInt16(ctx *unfoldCtx, v int16) error {
+	return u.process(ctx, int8(v))
+}
+
+func (u *userUnfolderInt8) OnInt32(ctx *unfoldCtx, v int32) error {
+	return u.process(ctx, int8(v))
+}
+
+func (u *userUnfolderInt8) OnInt64(ctx *unfoldCtx, v int64) error {
+	return u.process(ctx, int8(v))
+}
+
+func (u *userUnfolderInt8) OnFloat32(ctx *unfoldCtx, v float32) error {
+	return u.process(ctx, int8(v))
+}
+
+func (u *userUnfolderInt8) OnFloat64(ctx *unfoldCtx, v float64) error {
+	return u.process(ctx, int8(v))
+}
+
+func (u *userUnfolderInt16) OnNil(ctx *unfoldCtx) error {
+	return u.process(ctx, 0)
+}
+
+func (u *userUnfolderInt16) OnByte(ctx *unfoldCtx, v byte) error {
+	return u.process(ctx, int16(v))
+}
+
+func (u *userUnfolderInt16) OnUint(ctx *unfoldCtx, v uint) error {
+	return u.process(ctx, int16(v))
+}
+
+func (u *userUnfolderInt16) OnUint8(ctx *unfoldCtx, v uint8) error {
+	return u.process(ctx, int16(v))
+}
+
+func (u *userUnfolderInt16) OnUint16(ctx *unfoldCtx, v uint16) error {
+	return u.process(ctx, int16(v))
+}
+
+func (u *userUnfolderInt16) OnUint32(ctx *unfoldCtx, v uint32) error {
+	return u.process(ctx, int16(v))
+}
+
+func (u *userUnfolderInt16) OnUint64(ctx *unfoldCtx, v uint64) error {
+	return u.process(ctx, int16(v))
+}
+
+func (u *userUnfolderInt16) OnInt(ctx *unfoldCtx, v int) error {
+	return u.process(ctx, int16(v))
+}
+
+func (u *userUnfolderInt16) OnInt8(ctx *unfoldCtx, v int8) error {
+	return u.process(ctx, int16(v))
+}
+
+func (u *userUnfolderInt16) OnInt16(ctx *unfoldCtx, v int16) error {
+	return u.process(ctx, int16(v))
+}
+
+func (u *userUnfolderInt16) OnInt32(ctx *unfoldCtx, v int32) error {
+	return u.process(ctx, int16(v))
+}
+
+func (u *userUnfolderInt16) OnInt64(ctx *unfoldCtx, v int64) error {
+	return u.process(ctx, int16(v))
+}
+
+func (u *userUnfolderInt16) OnFloat32(ctx *unfoldCtx, v float32) error {
+	return u.process(ctx, int16(v))
+}
+
+func (u *userUnfolderInt16) OnFloat64(ctx *unfoldCtx, v float64) error {
+	return u.process(ctx, int16(v))
+}
+
+func (u *userUnfolderInt32) OnNil(ctx *unfoldCtx) error {
+	return u.process(ctx, 0)
+}
+
+func (u *userUnfolderInt32) OnByte(ctx *unfoldCtx, v byte) error {
+	return u.process(ctx, int32(v))
+}
+
+func (u *userUnfolderInt32) OnUint(ctx *unfoldCtx, v uint) error {
+	return u.process(ctx, int32(v))
+}
+
+func (u *userUnfolderInt32) OnUint8(ctx *unfoldCtx, v uint8) error {
+	return u.process(ctx, int32(v))
+}
+
+func (u *userUnfolderInt32) OnUint16(ctx *unfoldCtx, v uint16) error {
+	return u.process(ctx, int32(v))
+}
+
+func (u *userUnfolderInt32) OnUint32(ctx *unfoldCtx, v uint32) error {
+	return u.process(ctx, int32(v))
+}
+
+func (u *userUnfolderInt32) OnUint64(ctx *unfoldCtx, v uint64) error {
+	return u.process(ctx, int32(v))
+}
+
+func (u *userUnfolderInt32) OnInt(ctx *unfoldCtx, v int) error {
+	return u.process(ctx, int32(v))
+}
+
+func (u *userUnfolderInt32) OnInt8(ctx *unfoldCtx, v int8) error {
+	return u.process(ctx, int32(v))
+}
+
+func (u *userUnfolderInt32) OnInt16(ctx *unfoldCtx, v int16) error {
+	return u.process(ctx, int32(v))
+}
+
+func (u *userUnfolderInt32) OnInt32(ctx *unfoldCtx, v int32) error {
+	return u.process(ctx, int32(v))
+}
+
+func (u *userUnfolderInt32) OnInt64(ctx *unfoldCtx, v int64) error {
+	return u.process(ctx, int32(v))
+}
+
+func (u *userUnfolderInt32) OnFloat32(ctx *unfoldCtx, v float32) error {
+	return u.process(ctx, int32(v))
+}
+
+func (u *userUnfolderInt32) OnFloat64(ctx *unfoldCtx, v float64) error {
+	return u.process(ctx, int32(v))
+}
+
+func (u *userUnfolderInt64) OnNil(ctx *unfoldCtx) error {
+	return u.process(ctx, 0)
+}
+
+func (u *userUnfolderInt64) OnByte(ctx *unfoldCtx, v byte) error {
+	return u.process(ctx, int64(v))
+}
+
+func (u *userUnfolderInt64) OnUint(ctx *unfoldCtx, v uint) error {
+	return u.process(ctx, int64(v))
+}
+
+func (u *userUnfolderInt64) OnUint8(ctx *unfoldCtx, v uint8) error {
+	return u.process(ctx, int64(v))
+}
+
+func (u *userUnfolderInt64) OnUint16(ctx *unfoldCtx, v uint16) error {
+	return u.process(ctx, int64(v))
+}
+
+func (u *userUnfolderInt64) OnUint32(ctx *unfoldCtx, v uint32) error {
+	return u.process(ctx, int64(v))
+}
+
+func (u *userUnfolderInt64) OnUint64(ctx *unfoldCtx, v uint64) error {
+	return u.process(ctx, int64(v))
+}
+
+func (u *userUnfolderInt64) OnInt(ctx *unfoldCtx, v int) error {
+	return u.process(ctx, int64(v))
+}
+
+func (u *userUnfolderInt64) OnInt8(ctx *unfoldCtx, v int8) error {
+	return u.process(ctx, int64(v))
+}
+
+func (u *userUnfolderInt64) OnInt16(ctx *unfoldCtx, v int16) error {
+	return u.process(ctx, int64(v))
+}
+
+func (u *userUnfolderInt64) OnInt32(ctx *unfoldCtx, v int32) error {
+	return u.process(ctx, int64(v))
+}
+
+func (u *userUnfolderInt64) OnInt64(ctx *unfoldCtx, v int64) error {
+	return u.process(ctx, int64(v))
+}
+
+func (u *userUnfolderInt64) OnFloat32(ctx *unfoldCtx, v float32) error {
+	return u.process(ctx, int64(v))
+}
+
+func (u *userUnfolderInt64) OnFloat64(ctx *unfoldCtx, v float64) error {
+	return u.process(ctx, int64(v))
+}
+
+func (u *userUnfolderFloat32) OnNil(ctx *unfoldCtx) error {
+	return u.process(ctx, 0)
+}
+
+func (u *userUnfolderFloat32) OnByte(ctx *unfoldCtx, v byte) error {
+	return u.process(ctx, float32(v))
+}
+
+func (u *userUnfolderFloat32) OnUint(ctx *unfoldCtx, v uint) error {
+	return u.process(ctx, float32(v))
+}
+
+func (u *userUnfolderFloat32) OnUint8(ctx *unfoldCtx, v uint8) error {
+	return u.process(ctx, float32(v))
+}
+
+func (u *userUnfolderFloat32) OnUint16(ctx *unfoldCtx, v uint16) error {
+	return u.process(ctx, float32(v))
+}
+
+func (u *userUnfolderFloat32) OnUint32(ctx *unfoldCtx, v uint32) error {
+	return u.process(ctx, float32(v))
+}
+
+func (u *userUnfolderFloat32) OnUint64(ctx *unfoldCtx, v uint64) error {
+	return u.process(ctx, float32(v))
+}
+
+func (u *userUnfolderFloat32) OnInt(ctx *unfoldCtx, v int) error {
+	return u.process(ctx, float32(v))
+}
+
+func (u *userUnfolderFloat32) OnInt8(ctx *unfoldCtx, v int8) error {
+	return u.process(ctx, float32(v))
+}
+
+func (u *userUnfolderFloat32) OnInt16(ctx *unfoldCtx, v int16) error {
+	return u.process(ctx, float32(v))
+}
+
+func (u *userUnfolderFloat32) OnInt32(ctx *unfoldCtx, v int32) error {
+	return u.process(ctx, float32(v))
+}
+
+func (u *userUnfolderFloat32) OnInt64(ctx *unfoldCtx, v int64) error {
+	return u.process(ctx, float32(v))
+}
+
+func (u *userUnfolderFloat32) OnFloat32(ctx *unfoldCtx, v float32) error {
+	return u.process(ctx, float32(v))
+}
+
+func (u *userUnfolderFloat32) OnFloat64(ctx *unfoldCtx, v float64) error {
+	return u.process(ctx, float32(v))
+}
+
+func (u *userUnfolderFloat64) OnNil(ctx *unfoldCtx) error {
+	return u.process(ctx, 0)
+}
+
+func (u *userUnfolderFloat64) OnByte(ctx *unfoldCtx, v byte) error {
+	return u.process(ctx, float64(v))
+}
+
+func (u *userUnfolderFloat64) OnUint(ctx *unfoldCtx, v uint) error {
+	return u.process(ctx, float64(v))
+}
+
+func (u *userUnfolderFloat64) OnUint8(ctx *unfoldCtx, v uint8) error {
+	return u.process(ctx, float64(v))
+}
+
+func (u *userUnfolderFloat64) OnUint16(ctx *unfoldCtx, v uint16) error {
+	return u.process(ctx, float64(v))
+}
+
+func (u *userUnfolderFloat64) OnUint32(ctx *unfoldCtx, v uint32) error {
+	return u.process(ctx, float64(v))
+}
+
+func (u *userUnfolderFloat64) OnUint64(ctx *unfoldCtx, v uint64) error {
+	return u.process(ctx, float64(v))
+}
+
+func (u *userUnfolderFloat64) OnInt(ctx *unfoldCtx, v int) error {
+	return u.process(ctx, float64(v))
+}
+
+func (u *userUnfolderFloat64) OnInt8(ctx *unfoldCtx, v int8) error {
+	return u.process(ctx, float64(v))
+}
+
+func (u *userUnfolderFloat64) OnInt16(ctx *unfoldCtx, v int16) error {
+	return u.process(ctx, float64(v))
+}
+
+func (u *userUnfolderFloat64) OnInt32(ctx *unfoldCtx, v int32) error {
+	return u.process(ctx, float64(v))
+}
+
+func (u *userUnfolderFloat64) OnInt64(ctx *unfoldCtx, v int64) error {
+	return u.process(ctx, float64(v))
+}
+
+func (u *userUnfolderFloat64) OnFloat32(ctx *unfoldCtx, v float32) error {
+	return u.process(ctx, float64(v))
+}
+
+func (u *userUnfolderFloat64) OnFloat64(ctx *unfoldCtx, v float64) error {
+	return u.process(ctx, float64(v))
+}

--- a/gotype/unfold_user_primitive.yml
+++ b/gotype/unfold_user_primitive.yml
@@ -1,0 +1,82 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import:
+  - unfold_templates.yml
+
+main: |
+  package gotype
+
+  {{/* define pointer based user unfolder types */}}
+  {{ template "makeType" "bool" }}
+  {{ template "makeType" "string" }}
+  {{ range .numTypes }} 
+    {{ template "makeType" . }}
+  {{ end }}
+
+  {{/* create value visitor callbacks */}}
+  {{ invoke "onBoolFns" "name" "userUnfolderBool" "fn" "process" }}
+  {{ invoke "onStringFns" "name" "userUnfolderString" "fn" "process" }}
+  {{ range .numTypes }}
+    {{ $type := . }}
+    {{ $name := capitalize . | printf "userUnfolder%v" }}
+    {{ invoke "onNumberFns" "name" $name "type" $type "fn" "process" }}
+  {{ end }}
+
+# makeTypeWithName(name, type, [base])
+templates.makeTypeWithName: |
+  {{ $type := .type }}
+  {{ $name := capitalize .name | printf "userUnfolder%v" }}
+  {{ invoke "makeUserUnfoldType" "type" $type "name" $name "base" .base }}
+
+  func (u *{{ $name }} ) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+    ctx.unfolder.push(u)
+    ctx.ptr.push(ptr)
+  }
+
+  func (u *{{ $name }} ) cleanup(ctx *unfoldCtx) {
+    ctx.unfolder.pop()
+    ctx.ptr.pop()
+  }
+
+  func (u *{{ $name }}) process(ctx *unfoldCtx, v {{ $type }}) error {
+    err := u.fn(ctx.ptr.current, v)
+    u.cleanup(ctx)
+    return err
+  }
+
+templates.makeUserUnfoldType: |
+  {{ $type := .type }}
+  {{ $name := .name }}
+  {{ $cbname := .name | printf "%vCB" }}
+  {{ $base := default "unfolderErrUnknown" .base }}
+
+  type (
+    {{ $name }} struct {
+      {{ $base }}
+      fn {{ $cbname }}
+    }
+
+    {{ $cbname }} func(unsafe.Pointer, {{ $type }}) error
+  )
+
+  func new{{ $name | capitalize }}(fn reflect.Value) ptrUnfolder {
+    return &{{ $name }}{
+      fn: *((*{{ $cbname }})(stunsafe.UnsafeFnPtr(fn))),
+    }
+  }
+

--- a/gotype/unfold_user_processing.generated.go
+++ b/gotype/unfold_user_processing.generated.go
@@ -1,0 +1,263 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This file has been generated from 'unfold_user_processing.yml', do not edit
+package gotype
+
+import (
+	"reflect"
+	"unsafe"
+
+	structform "github.com/elastic/go-structform"
+)
+
+type unfolderUserProcessingInit struct {
+	fnInit userProcessingInitFn
+}
+
+type unfolderUserFailing struct {
+	err error
+}
+
+type unfolderUserProcessing struct {
+	// XXX: move user processing into unfoldCtx as stacks? -> no more allocations
+	startSz int
+	fn      userProcessingFn
+}
+
+type userProcessingInitFn func(unsafe.Pointer) (interface{}, userProcessingFn)
+
+type userProcessingFn func(unsafe.Pointer, interface{})
+
+func (u *unfolderUserProcessingInit) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+	cell, cont := u.fnInit(ptr)
+
+	unfolder, err := lookupReflUnfolder(ctx, reflect.TypeOf(cell), false)
+	if err != nil {
+		// Use unfolderUserFailing. If there is a chance that the no value is
+		// unfolded into the current target, then we can continue processing
+		// without reporting said error.
+		ctx.unfolder.push(&unfolderUserFailing{err})
+		return
+	}
+
+	startSz := len(ctx.unfolder.stack)
+
+	v := reflect.ValueOf(cell)
+	ctx.ptr.push(ptr)
+	ctx.value.push(v)
+
+	unfolder.initState(ctx, v)
+	ctx.unfolder.push(&unfolderUserProcessing{
+		startSz: startSz,
+		fn:      cont,
+	})
+}
+
+func (u *unfolderUserFailing) OnNil(*unfoldCtx) error                                   { return u.err }
+func (u *unfolderUserFailing) OnBool(*unfoldCtx, bool) error                            { return u.err }
+func (u *unfolderUserFailing) OnByte(*unfoldCtx, byte) error                            { return u.err }
+func (u *unfolderUserFailing) OnString(*unfoldCtx, string) error                        { return u.err }
+func (u *unfolderUserFailing) OnStringRef(*unfoldCtx, []byte) error                     { return u.err }
+func (u *unfolderUserFailing) OnInt8(*unfoldCtx, int8) error                            { return u.err }
+func (u *unfolderUserFailing) OnInt16(*unfoldCtx, int16) error                          { return u.err }
+func (u *unfolderUserFailing) OnInt32(*unfoldCtx, int32) error                          { return u.err }
+func (u *unfolderUserFailing) OnInt64(*unfoldCtx, int64) error                          { return u.err }
+func (u *unfolderUserFailing) OnInt(*unfoldCtx, int) error                              { return u.err }
+func (u *unfolderUserFailing) OnUint8(*unfoldCtx, uint8) error                          { return u.err }
+func (u *unfolderUserFailing) OnUint16(*unfoldCtx, uint16) error                        { return u.err }
+func (u *unfolderUserFailing) OnUint32(*unfoldCtx, uint32) error                        { return u.err }
+func (u *unfolderUserFailing) OnUint64(*unfoldCtx, uint64) error                        { return u.err }
+func (u *unfolderUserFailing) OnUint(*unfoldCtx, uint) error                            { return u.err }
+func (u *unfolderUserFailing) OnFloat32(*unfoldCtx, float32) error                      { return u.err }
+func (u *unfolderUserFailing) OnFloat64(*unfoldCtx, float64) error                      { return u.err }
+func (u *unfolderUserFailing) OnArrayStart(*unfoldCtx, int, structform.BaseType) error  { return u.err }
+func (u *unfolderUserFailing) OnArrayFinished(*unfoldCtx) error                         { return u.err }
+func (u *unfolderUserFailing) OnChildArrayDone(*unfoldCtx) error                        { return u.err }
+func (u *unfolderUserFailing) OnObjectStart(*unfoldCtx, int, structform.BaseType) error { return u.err }
+func (u *unfolderUserFailing) OnObjectFinished(*unfoldCtx) error                        { return u.err }
+func (u *unfolderUserFailing) OnKey(*unfoldCtx, string) error                           { return u.err }
+func (u *unfolderUserFailing) OnKeyRef(*unfoldCtx, []byte) error                        { return u.err }
+func (u *unfolderUserFailing) OnChildObjectDone(*unfoldCtx) error                       { return u.err }
+
+func (u *unfolderUserProcessing) beforeCall(ctx *unfoldCtx) {
+	ctx.unfolder.pop() // temporarily remove unfolder from top of stack
+}
+
+func (u *unfolderUserProcessing) afterCall(ctx *unfoldCtx, err error) error {
+	if err != nil {
+		return err
+	}
+
+	if u.startSz >= len(ctx.unfolder.stack) {
+		u.fn(ctx.ptr.pop(), ctx.value.pop().Interface())
+	} else {
+		// add myself again, so we can intercept future calls
+		ctx.unfolder.push(u)
+	}
+	return nil
+}
+
+func (u *unfolderUserProcessing) OnNil(ctx *unfoldCtx) error {
+	u.beforeCall(ctx)
+	err := ctx.OnNil()
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnStringRef(ctx *unfoldCtx, v []byte) error {
+	u.beforeCall(ctx)
+	err := ctx.OnStringRef(v)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnBool(ctx *unfoldCtx, v bool) error {
+	u.beforeCall(ctx)
+	err := ctx.OnBool(v)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnString(ctx *unfoldCtx, v string) error {
+	u.beforeCall(ctx)
+	err := ctx.OnString(v)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnUint(ctx *unfoldCtx, v uint) error {
+	u.beforeCall(ctx)
+	err := ctx.OnUint(v)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnUint8(ctx *unfoldCtx, v uint8) error {
+	u.beforeCall(ctx)
+	err := ctx.OnUint8(v)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnUint16(ctx *unfoldCtx, v uint16) error {
+	u.beforeCall(ctx)
+	err := ctx.OnUint16(v)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnUint32(ctx *unfoldCtx, v uint32) error {
+	u.beforeCall(ctx)
+	err := ctx.OnUint32(v)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnUint64(ctx *unfoldCtx, v uint64) error {
+	u.beforeCall(ctx)
+	err := ctx.OnUint64(v)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnInt(ctx *unfoldCtx, v int) error {
+	u.beforeCall(ctx)
+	err := ctx.OnInt(v)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnInt8(ctx *unfoldCtx, v int8) error {
+	u.beforeCall(ctx)
+	err := ctx.OnInt8(v)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnInt16(ctx *unfoldCtx, v int16) error {
+	u.beforeCall(ctx)
+	err := ctx.OnInt16(v)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnInt32(ctx *unfoldCtx, v int32) error {
+	u.beforeCall(ctx)
+	err := ctx.OnInt32(v)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnInt64(ctx *unfoldCtx, v int64) error {
+	u.beforeCall(ctx)
+	err := ctx.OnInt64(v)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnFloat32(ctx *unfoldCtx, v float32) error {
+	u.beforeCall(ctx)
+	err := ctx.OnFloat32(v)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnFloat64(ctx *unfoldCtx, v float64) error {
+	u.beforeCall(ctx)
+	err := ctx.OnFloat64(v)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnByte(ctx *unfoldCtx, v byte) error {
+	u.beforeCall(ctx)
+	err := ctx.OnByte(v)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnArrayStart(ctx *unfoldCtx, v int, bt structform.BaseType) error {
+	u.beforeCall(ctx)
+	err := ctx.OnArrayStart(v, bt)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnArrayFinished(ctx *unfoldCtx) error {
+	u.beforeCall(ctx)
+	err := ctx.OnArrayFinished()
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnChildArrayDone(ctx *unfoldCtx) error {
+	u.beforeCall(ctx)
+	err := ctx.unfolder.current.OnChildArrayDone(ctx)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnObjectStart(ctx *unfoldCtx, v int, bt structform.BaseType) error {
+	u.beforeCall(ctx)
+	err := ctx.OnObjectStart(v, bt)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnObjectFinished(ctx *unfoldCtx) error {
+	u.beforeCall(ctx)
+	err := ctx.OnObjectFinished()
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnChildObjectDone(ctx *unfoldCtx) error {
+	u.beforeCall(ctx)
+	err := ctx.unfolder.current.OnChildObjectDone(ctx)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnKey(ctx *unfoldCtx, v string) error {
+	u.beforeCall(ctx)
+	err := ctx.OnKey(v)
+	return u.afterCall(ctx, err)
+}
+
+func (u *unfolderUserProcessing) OnKeyRef(ctx *unfoldCtx, v []byte) error {
+	u.beforeCall(ctx)
+	err := ctx.OnKeyRef(v)
+	return u.afterCall(ctx, err)
+}

--- a/gotype/unfold_user_processing.yml
+++ b/gotype/unfold_user_processing.yml
@@ -37,7 +37,7 @@ main: |
 
   type userProcessingInitFn func(unsafe.Pointer) (interface{}, userProcessingFn)
 
-  type userProcessingFn func(unsafe.Pointer, interface{})
+  type userProcessingFn func(unsafe.Pointer, interface{}) error
 
   func (u *unfolderUserProcessingInit) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
     cell, cont := u.fnInit(ptr)
@@ -93,19 +93,22 @@ main: |
   func (u *unfolderUserProcessing) beforeCall(ctx *unfoldCtx) {
     ctx.unfolder.pop() // temporarily remove unfolder from top of stack
   }
-  
+
   func (u *unfolderUserProcessing) afterCall(ctx *unfoldCtx, err error) error {
     if err != nil {
       return err
     }
 
     if u.startSz >= len(ctx.unfolder.stack) {
-      u.fn(ctx.ptr.pop(), ctx.value.pop().Interface())
-    } else {
-      // add myself again, so we can intercept future calls
-      ctx.unfolder.push(u) 
+      return u.finalize(ctx)
     }
+
+    ctx.unfolder.push(u)
     return nil
+  }
+
+  func (u *unfolderUserProcessing) finalize(ctx *unfoldCtx) error {
+    return u.fn(ctx.ptr.pop(), ctx.value.pop().Interface())
   }
 
   func (u *unfolderUserProcessing) OnNil(ctx *unfoldCtx) error {
@@ -142,7 +145,7 @@ main: |
     err := ctx.OnKey(v)
     return u.afterCall(ctx, err)
   }
-  
+
   func (u *unfolderUserProcessing) OnKeyRef(ctx *unfoldCtx, v []byte) error {
     u.beforeCall(ctx)
     err := ctx.OnKeyRef(v)
@@ -155,13 +158,13 @@ templates.makeCallStructured: |
   {{ $kind := .kind | capitalize }}
   func (u *unfolderUserProcessing) On{{ $kind }}Start(ctx *unfoldCtx, v int, bt structform.BaseType) error {
     u.beforeCall(ctx)
-    err := ctx.On{{ $kind }}Start(v, bt)
+    err := ctx.unfolder.current.On{{ $kind }}Start(ctx, v, bt)
     return u.afterCall(ctx, err)
   }
 
   func (u *unfolderUserProcessing) On{{ $kind }}Finished(ctx *unfoldCtx) error {
     u.beforeCall(ctx)
-    err := ctx.On{{ $kind }}Finished()
+    err := ctx.unfolder.current.On{{ $kind }}Finished(ctx)
     return u.afterCall(ctx, err)
   }
 

--- a/gotype/unfold_user_processing.yml
+++ b/gotype/unfold_user_processing.yml
@@ -1,0 +1,172 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import:
+  - unfold_templates.yml
+
+main: |
+  package gotype
+
+  type unfolderUserProcessingInit struct {
+    fnInit userProcessingInitFn
+  }
+
+  type unfolderUserFailing struct {
+    err error
+  }
+
+  type unfolderUserProcessing struct {
+    // XXX: move user processing into unfoldCtx as stacks? -> no more allocations
+    startSz int
+    fn      userProcessingFn
+  }
+
+  type userProcessingInitFn func(unsafe.Pointer) (interface{}, userProcessingFn)
+
+  type userProcessingFn func(unsafe.Pointer, interface{})
+
+  func (u *unfolderUserProcessingInit) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+    cell, cont := u.fnInit(ptr)
+
+    unfolder, err := lookupReflUnfolder(ctx, reflect.TypeOf(cell), false)
+    if err != nil {
+      // Use unfolderUserFailing. If there is a chance that the no value is
+      // unfolded into the current target, then we can continue processing
+      // without reporting said error.
+      ctx.unfolder.push(&unfolderUserFailing{err})
+      return
+    }
+
+    startSz := len(ctx.unfolder.stack)
+
+    v := reflect.ValueOf(cell)
+    ctx.ptr.push(ptr)
+    ctx.value.push(v)
+
+    unfolder.initState(ctx, v)
+    ctx.unfolder.push(&unfolderUserProcessing{
+      startSz: startSz,
+      fn:      cont,
+    })
+  }
+
+  func (u *unfolderUserFailing) OnNil(*unfoldCtx) error                                   { return u.err }
+  func (u *unfolderUserFailing) OnBool(*unfoldCtx, bool) error                            { return u.err }
+  func (u *unfolderUserFailing) OnByte(*unfoldCtx, byte) error                            { return u.err }
+  func (u *unfolderUserFailing) OnString(*unfoldCtx, string) error                        { return u.err }
+  func (u *unfolderUserFailing) OnStringRef(*unfoldCtx, []byte) error                     { return u.err }
+  func (u *unfolderUserFailing) OnInt8(*unfoldCtx, int8) error                            { return u.err }
+  func (u *unfolderUserFailing) OnInt16(*unfoldCtx, int16) error                          { return u.err }
+  func (u *unfolderUserFailing) OnInt32(*unfoldCtx, int32) error                          { return u.err }
+  func (u *unfolderUserFailing) OnInt64(*unfoldCtx, int64) error                          { return u.err }
+  func (u *unfolderUserFailing) OnInt(*unfoldCtx, int) error                              { return u.err }
+  func (u *unfolderUserFailing) OnUint8(*unfoldCtx, uint8) error                          { return u.err }
+  func (u *unfolderUserFailing) OnUint16(*unfoldCtx, uint16) error                        { return u.err }
+  func (u *unfolderUserFailing) OnUint32(*unfoldCtx, uint32) error                        { return u.err }
+  func (u *unfolderUserFailing) OnUint64(*unfoldCtx, uint64) error                        { return u.err }
+  func (u *unfolderUserFailing) OnUint(*unfoldCtx, uint) error                            { return u.err }
+  func (u *unfolderUserFailing) OnFloat32(*unfoldCtx, float32) error                      { return u.err }
+  func (u *unfolderUserFailing) OnFloat64(*unfoldCtx, float64) error                      { return u.err }
+  func (u *unfolderUserFailing) OnArrayStart(*unfoldCtx, int, structform.BaseType) error  { return u.err }
+  func (u *unfolderUserFailing) OnArrayFinished(*unfoldCtx) error                         { return u.err }
+  func (u *unfolderUserFailing) OnChildArrayDone(*unfoldCtx) error                        { return u.err }
+  func (u *unfolderUserFailing) OnObjectStart(*unfoldCtx, int, structform.BaseType) error { return u.err }
+  func (u *unfolderUserFailing) OnObjectFinished(*unfoldCtx) error                        { return u.err }
+  func (u *unfolderUserFailing) OnKey(*unfoldCtx, string) error                           { return u.err }
+  func (u *unfolderUserFailing) OnKeyRef(*unfoldCtx, []byte) error                        { return u.err }
+  func (u *unfolderUserFailing) OnChildObjectDone(*unfoldCtx) error                       { return u.err }
+
+  func (u *unfolderUserProcessing) beforeCall(ctx *unfoldCtx) {
+    ctx.unfolder.pop() // temporarily remove unfolder from top of stack
+  }
+  
+  func (u *unfolderUserProcessing) afterCall(ctx *unfoldCtx, err error) error {
+    if err != nil {
+      return err
+    }
+
+    if u.startSz >= len(ctx.unfolder.stack) {
+      u.fn(ctx.ptr.pop(), ctx.value.pop().Interface())
+    } else {
+      // add myself again, so we can intercept future calls
+      ctx.unfolder.push(u) 
+    }
+    return nil
+  }
+
+  func (u *unfolderUserProcessing) OnNil(ctx *unfoldCtx) error {
+    u.beforeCall(ctx)
+    err := ctx.OnNil()
+    return u.afterCall(ctx, err)
+  }
+
+  func (u *unfolderUserProcessing) OnStringRef(ctx *unfoldCtx, v []byte) error {
+    u.beforeCall(ctx)
+    err := ctx.OnStringRef(v)
+    return u.afterCall(ctx, err)
+  }
+
+  {{ range data.primitiveTypes }}
+  func (u *unfolderUserProcessing) On{{ capitalize . }}(ctx *unfoldCtx, v {{ . }}) error {
+    u.beforeCall(ctx)
+    err := ctx.On{{ capitalize . }}(v)
+    return u.afterCall(ctx, err)
+  }
+  {{ end }}
+
+  func (u *unfolderUserProcessing) OnByte(ctx *unfoldCtx, v byte) error {
+    u.beforeCall(ctx)
+    err := ctx.OnByte(v)
+    return u.afterCall(ctx, err)
+  }
+
+  {{ invoke "makeCallStructured" "kind" "array" }}
+  {{ invoke "makeCallStructured" "kind" "object" }}
+
+  func (u *unfolderUserProcessing) OnKey(ctx *unfoldCtx, v string) error {
+    u.beforeCall(ctx)
+    err := ctx.OnKey(v)
+    return u.afterCall(ctx, err)
+  }
+  
+  func (u *unfolderUserProcessing) OnKeyRef(ctx *unfoldCtx, v []byte) error {
+    u.beforeCall(ctx)
+    err := ctx.OnKeyRef(v)
+    return u.afterCall(ctx, err)
+  }
+
+
+# makeCallStructured(kind)
+templates.makeCallStructured: |
+  {{ $kind := .kind | capitalize }}
+  func (u *unfolderUserProcessing) On{{ $kind }}Start(ctx *unfoldCtx, v int, bt structform.BaseType) error {
+    u.beforeCall(ctx)
+    err := ctx.On{{ $kind }}Start(v, bt)
+    return u.afterCall(ctx, err)
+  }
+
+  func (u *unfolderUserProcessing) On{{ $kind }}Finished(ctx *unfoldCtx) error {
+    u.beforeCall(ctx)
+    err := ctx.On{{ $kind }}Finished()
+    return u.afterCall(ctx, err)
+  }
+
+  func (u *unfolderUserProcessing) OnChild{{ $kind }}Done(ctx *unfoldCtx) error {
+    u.beforeCall(ctx)
+    err := ctx.unfolder.current.OnChild{{ $kind }}Done(ctx)
+    return u.afterCall(ctx, err)
+  }


### PR DESCRIPTION
The `gotype.NewUnfolder` constructor now accepts functional options. Currently only the `Unfolders` option is supported. `Unfolders` accepts a number of primitive or processing unfolders. These are plain functions with different signature, depending on target type and required processing. See `TestUserUnfold` for sample use cases.

For rich structures the unfolder pre-computes and stores unfolders for compound structures. This cache used to be global/shared, and protected via a mutex. With the introduction of user unfolders the cache is not shared anymore, due to potential conflicts between type representations. Each instance of `gotype.Unfolder` no has a local cache only. The unfolder was not thread safe before. There is no change in semantics for library users.

**Primitive user unfolders**: Primitive unfolders are used for converting a primitive value into the target type. The type signature for a primitive unfolder must be:
`func(to *Target, from P) error`, where `to` is an arbitrary go type that the result should be written to and `P` must be one of: `bool, string, uint(8|16|32|64), int(8|16|32|64), float(32|64)`. The unfolder will be used for any value of type `Target` or `*Target`.
Unfolding fails if the value presented to the unfolder is not compatible with `P`.

**Processing user unfolder**: Processing unfolders provide an init function, that returns a memory cell for temporary parsing and a post processing function. `gotype` first parses the input according to the type of the memory cell. This way one can parse an array or object into a temporary value, and then compute the actual value matching the target type.
The signature of the `init` function is: `func(to *Target) (cell interface{}, after processFn)`. The init receives a pointer to the target value of type `Target`. The init function can pre-initialize `to` if required. It returns a temporary store for parsing purposes via `cell`. If the type/byte layout doesn't change, then one can return `*to` for cell. The `processFn` signature is: `func(to *Target, cell interface{}) error`. Both, the target pointer and cell are given to the processing function again (no closure to store intermediate state is required). If the `Target` type is not reachable from the `Target` type itself, then it is safe to allocate and reuse the `cell` between multiple calls. But each instance of `gotype.Unfolder` must have it's own preallocated `cell`.