### PR TITLE
define Expander interface

### DIFF
--- a/gotype/defs.go
+++ b/gotype/defs.go
@@ -50,6 +50,7 @@ var (
 
 	tExtVisitor  = reflect.TypeOf((*structform.ExtVisitor)(nil)).Elem()
 	tFolder      = reflect.TypeOf((*Folder)(nil)).Elem()
+	tExpander    = reflect.TypeOf((*Expander)(nil)).Elem()
 	tUnfoldState = reflect.TypeOf((*UnfoldState)(nil)).Elem()
 )
 

--- a/gotype/unfold_lookup_go.generated.go
+++ b/gotype/unfold_lookup_go.generated.go
@@ -347,6 +347,10 @@ func lookupReflUnfolder(ctx *unfoldCtx, t reflect.Type, withUser bool) (reflUnfo
 		}
 	}
 
+	if t.Implements(tExpander) {
+		return newExpanderInit(), nil
+	}
+
 	if f := ctx.reg.find(t); f != nil {
 		return f, nil
 	}
@@ -434,6 +438,10 @@ func buildReflUnfolder(ctx *unfoldCtx, t reflect.Type) (reflUnfolder, error) {
 			return newUnfolderReflSlice(unfolderElem), nil
 		}
 
+		if reflect.PtrTo(et).Implements(tExpander) {
+			return newUnfolderReflSlice(newExpanderInit()), nil
+		}
+
 		switch et.Kind() {
 		case reflect.Interface:
 			return unfolderReflArrIfc, nil
@@ -493,6 +501,10 @@ func buildReflUnfolder(ctx *unfoldCtx, t reflect.Type) (reflUnfolder, error) {
 
 		if unfolderElem := lookupReflUser(ctx, et); unfolderElem != nil {
 			return newUnfolderReflMap(unfolderElem), nil
+		}
+
+		if reflect.PtrTo(et).Implements(tExpander) {
+			return newUnfolderReflMap(newExpanderInit()), nil
 		}
 
 		switch et.Kind() {

--- a/gotype/unfold_lookup_go.yml
+++ b/gotype/unfold_lookup_go.yml
@@ -101,6 +101,10 @@ main: |
       }
     }
 
+    if t.Implements(tExpander) {
+      return newExpanderInit(), nil
+    }
+
     if f := ctx.reg.find(t); f != nil {
       return f, nil
     }
@@ -150,6 +154,10 @@ main: |
         return newUnfolderReflSlice(unfolderElem), nil
       }
 
+      if reflect.PtrTo(et).Implements(tExpander) {
+        return newUnfolderReflSlice(newExpanderInit()), nil
+      }
+
       switch et.Kind() {
       case reflect.Interface:
         return unfolderReflArrIfc, nil
@@ -170,6 +178,10 @@ main: |
 
       if unfolderElem := lookupReflUser(ctx, et); unfolderElem != nil {
         return newUnfolderReflMap(unfolderElem), nil
+      }
+
+      if reflect.PtrTo(et).Implements(tExpander) {
+        return newUnfolderReflMap(newExpanderInit()), nil
       }
 
       switch et.Kind() {

--- a/gotype/unfold_opts.go
+++ b/gotype/unfold_opts.go
@@ -80,6 +80,10 @@ func makeUserUnfolderFns(in []interface{}) (map[reflect.Type]reflUnfolder, error
 	M := map[reflect.Type]reflUnfolder{}
 
 	for _, cur := range in {
+		if cur == nil {
+			continue
+		}
+
 		t, unfolder, err := makeUserUnfolder(reflect.ValueOf(cur))
 		if err != nil {
 			return nil, err

--- a/gotype/unfold_struct.go
+++ b/gotype/unfold_struct.go
@@ -128,6 +128,8 @@ func makeFieldUnfolder(ctx *unfoldCtx, st reflect.StructField) (fieldUnfolder, e
 
 	if uu := lookupReflUser(ctx, targetType); uu != nil {
 		fu.initState = wrapReflUnfolder(st.Type, uu)
+	} else if targetType.Implements(tExpander) {
+		fu.initState = wrapReflUnfolder(st.Type, newExpanderInit())
 	} else if pu := lookupGoPtrUnfolder(st.Type); pu != nil {
 		fu.initState = pu.initState
 	} else {


### PR DESCRIPTION
The Expander interface allows types to provide a method `Expand() UnfoldState`,
so to directly customize the unfolding process.