### PR TITLE
Fix possible memory confusion in unsafe slice cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix potential use after free in string and []byte conversions. (PR #21)
+
 ## [0.0.6]
 
 ### Added

--- a/internal/unsafe/unsafe.go
+++ b/internal/unsafe/unsafe.go
@@ -19,6 +19,7 @@ package unsafe
 
 import (
 	"reflect"
+	"runtime"
 	"unsafe"
 )
 
@@ -33,6 +34,7 @@ func Str2Bytes(s string) (b []byte) {
 	bh.Data = sh.Data
 	bh.Cap = sh.Len
 	bh.Len = sh.Len
+	runtime.KeepAlive(s)
 	return
 }
 
@@ -41,6 +43,7 @@ func Bytes2Str(b []byte) (s string) {
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
 	sh.Data = bh.Data
 	sh.Len = bh.Len
+	runtime.KeepAlive(b)
 	return
 }
 

--- a/internal/unsafe/unsafe.go
+++ b/internal/unsafe/unsafe.go
@@ -20,7 +20,6 @@ package unsafe
 import (
 	"reflect"
 	"unsafe"
-	"runtime"
 )
 
 type emptyInterface struct {
@@ -28,25 +27,21 @@ type emptyInterface struct {
 	word unsafe.Pointer
 }
 
-func Str2Bytes(s string) []byte {
-	b := make([]byte, 0, 0)
+func Str2Bytes(s string) (b []byte) {
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
 	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 	bh.Data = sh.Data
 	bh.Cap = sh.Len
 	bh.Len = sh.Len
-	runtime.KeepAlive(s)
-	return b
+	return
 }
 
-func Bytes2Str(b []byte) string {
-	s := ""
+func Bytes2Str(b []byte) (s string) {
 	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
 	sh.Data = bh.Data
 	sh.Len = bh.Len
-	runtime.KeepAlive(b)
-	return s
+	return
 }
 
 // IfcValuePtr extracts the underlying values pointer from an empty interface{}

--- a/internal/unsafe/unsafe.go
+++ b/internal/unsafe/unsafe.go
@@ -20,6 +20,7 @@ package unsafe
 import (
 	"reflect"
 	"unsafe"
+	"runtime"
 )
 
 type emptyInterface struct {
@@ -28,16 +29,24 @@ type emptyInterface struct {
 }
 
 func Str2Bytes(s string) []byte {
+	b := make([]byte, 0, 0)
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bh := reflect.SliceHeader{Data: sh.Data, Len: sh.Len, Cap: sh.Len}
-	b := *(*[]byte)(unsafe.Pointer(&bh))
+	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	bh.Data = sh.Data
+	bh.Cap = sh.Len
+	bh.Len = sh.Len
+	runtime.KeepAlive(s)
 	return b
 }
 
 func Bytes2Str(b []byte) string {
+	s := ""
 	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	sh := reflect.StringHeader{Data: bh.Data, Len: bh.Len}
-	return *((*string)(unsafe.Pointer(&sh)))
+	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	sh.Data = bh.Data
+	sh.Len = bh.Len
+	runtime.KeepAlive(b)
+	return s
 }
 
 // IfcValuePtr extracts the underlying values pointer from an empty interface{}


### PR DESCRIPTION
I found incorrect casts from `string` to `[]byte` and vice versa in `internal/unsafe/unsafe.go`. The problem is that when `reflect.SliceHeader` is created as a composite literal (instead of deriving it from an actual slice by cast), then the Go garbage collector will not treat its `Data` field as a reference. If the GC runs just between creating the `SliceHeader` and casting it into the final, real `[]byte` slice, then the underlying data might have been collected already, effectively making the returned `[]byte` slice a dangling pointer.

This has a low probability to occur, but projects that import this library might still use it in a code path that gets executed a lot, thus increasing the probability to happen. Depending on the memory layout at the time of the GC run, this could potentially create an information leak vulnerability.

This PR changes the function to create the `reflect.SliceHeader` and, respectively, `reflect.StringHeader` from an actual slice / string by first instantiating the return value.