### PR TITLE
Remove EOL go version and add 1.16

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
         axes {
           axis {
             name 'GO_VERSION'
-            values '1.8', '1.9', '1.10', '1.11', '1.12', '1.15.6'
+            values '1.15.6', '1.16.2'
           }
         }
         stages {


### PR DESCRIPTION
Only test for maintained go version. Updating the minial go version allows us to use more modern API like errors.Is, errors.As, t.Cleanup and similar in the tests.