### PR TITLE
Add support for IsEmpty() callback for omitempty on custom types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-- Added `Emptiable` interface to allow custom types to report that they are 'empty'. A structs field is not serialized if the `omitempty` struct tag is set and `IsEmpty()` returns false. #32
+- Added `IsZeroer` interface to allow custom types to report that they are not initialized. A structs field is not serialized if the `omitempty` struct tag is set and `IsZero()` returns true. #32
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Added `Emptiable` interface to allow custom types to report that they are 'empty'. A structs field is not serialized if the `omitempty` struct tag is set and `IsEmpty()` returns false. #32
 
 ### Changed
 
@@ -13,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Ensure `Fold` can be called when a value is given by value, but the `Folder` interface is implemented on the pointer type. #32
 
 ## [0.0.8]
 

--- a/gotype/defs.go
+++ b/gotype/defs.go
@@ -52,7 +52,7 @@ var (
 	tFolder      = reflect.TypeOf((*Folder)(nil)).Elem()
 	tExpander    = reflect.TypeOf((*Expander)(nil)).Elem()
 	tUnfoldState = reflect.TypeOf((*UnfoldState)(nil)).Elem()
-	tEmptiable   = reflect.TypeOf((*Emptiable)(nil)).Elem()
+	tIsZeroer    = reflect.TypeOf((*IsZeroer)(nil)).Elem()
 )
 
 func bytes2Str(b []byte) string {
@@ -62,5 +62,5 @@ func bytes2Str(b []byte) string {
 func implementsFolder(t reflect.Type) bool    { return t.Implements(tFolder) }
 func implementsPtrFolder(t reflect.Type) bool { return implementsFolder(reflect.PtrTo(t)) }
 
-func implementsEmptiable(t reflect.Type) bool    { return t.Implements(tEmptiable) }
-func implementsPtrEmptiable(t reflect.Type) bool { return implementsEmptiable(reflect.PtrTo(t)) }
+func implementsIsZeroer(t reflect.Type) bool    { return t.Implements(tIsZeroer) }
+func implementsPtrIsZeroer(t reflect.Type) bool { return implementsIsZeroer(reflect.PtrTo(t)) }

--- a/gotype/defs.go
+++ b/gotype/defs.go
@@ -52,8 +52,15 @@ var (
 	tFolder      = reflect.TypeOf((*Folder)(nil)).Elem()
 	tExpander    = reflect.TypeOf((*Expander)(nil)).Elem()
 	tUnfoldState = reflect.TypeOf((*UnfoldState)(nil)).Elem()
+	tEmptiable   = reflect.TypeOf((*Emptiable)(nil)).Elem()
 )
 
 func bytes2Str(b []byte) string {
 	return unsafe.Bytes2Str(b)
 }
+
+func implementsFolder(t reflect.Type) bool    { return t.Implements(tFolder) }
+func implementsPtrFolder(t reflect.Type) bool { return implementsFolder(reflect.PtrTo(t)) }
+
+func implementsEmptiable(t reflect.Type) bool    { return t.Implements(tEmptiable) }
+func implementsPtrEmptiable(t reflect.Type) bool { return implementsEmptiable(reflect.PtrTo(t)) }

--- a/gotype/fold.go
+++ b/gotype/fold.go
@@ -39,11 +39,11 @@ type Folder interface {
 	Fold(structform.ExtVisitor) error
 }
 
-// Emptiable interface allows custom types to be reported as empty.
+// IsZeroer interface allows custom types to be reported as empty.
 // If the `omitempty` struct tag option is set and the custom type implements
-// IsEmpty(), which returns true, then the field will not be reported.
-type Emptiable interface {
-	IsEmpty() bool
+// IsZero(), which returns true, then the field will not be reported.
+type IsZeroer interface {
+	IsZero() bool
 }
 
 type foldContext struct {

--- a/gotype/fold.go
+++ b/gotype/fold.go
@@ -39,6 +39,13 @@ type Folder interface {
 	Fold(structform.ExtVisitor) error
 }
 
+// Emptiable interface allows custom types to be reported as empty.
+// If the `omitempty` struct tag option is set and the custom type implements
+// IsEmpty(), which returns true, then the field will not be reported.
+type Emptiable interface {
+	IsEmpty() bool
+}
+
 type foldContext struct {
 	visitor
 	userReg map[reflect.Type]reFoldFn

--- a/gotype/fold_primitives.go
+++ b/gotype/fold_primitives.go
@@ -55,5 +55,15 @@ func reFoldFloat64(C *foldContext, v reflect.Value) error { return C.OnFloat64(v
 func reFoldString(C *foldContext, v reflect.Value) error  { return C.OnString(v.String()) }
 
 func reFoldFolderIfc(C *foldContext, v reflect.Value) error {
-	return v.Interface().(Folder).Fold(C.visitor)
+	if implementsFolder(v.Type()) {
+		return v.Interface().(Folder).Fold(C.visitor)
+	}
+
+	if v.CanAddr() {
+		return reFoldFolderIfc(C, v.Addr())
+	}
+
+	tmp := reflect.New(v.Type())
+	tmp.Elem().Set(v)
+	return reFoldFolderIfc(C, tmp)
 }

--- a/gotype/fold_reflect.go
+++ b/gotype/fold_reflect.go
@@ -344,7 +344,7 @@ func makeResolveNonEmptyValue(st reflect.Type) func(reflect.Value) (reflect.Valu
 	}
 
 	resolveEmptiable := func(v reflect.Value) (reflect.Value, bool) {
-		empty := v.Interface().(Emptiable).IsEmpty()
+		empty := v.Interface().(IsZeroer).IsZero()
 		return v, !empty
 	}
 
@@ -387,9 +387,9 @@ func makeResolveNonEmptyValue(st reflect.Type) func(reflect.Value) (reflect.Valu
 		case reflect.Map, reflect.String, reflect.Slice, reflect.Array:
 			resolvers = append(resolvers, resolveBySize)
 		default:
-			if implementsEmptiable(st) {
+			if implementsIsZeroer(st) {
 				resolvers = append(resolvers, resolveEmptiable)
-			} else if implementsPtrEmptiable(st) {
+			} else if implementsPtrIsZeroer(st) {
 				resolvers = append(resolvers, resolveEmptiablePtr)
 			}
 		}

--- a/gotype/fold_reflect.go
+++ b/gotype/fold_reflect.go
@@ -52,7 +52,7 @@ func getReflectFold(c *foldContext, t reflect.Type) (reFoldFn, error) {
 		return f, nil
 	}
 
-	if t.Implements(tFolder) {
+	if implementsFolder(t) || implementsPtrFolder(t) {
 		f := reFoldFolderIfc
 		c.reg.set(t, f)
 		return f, nil
@@ -130,7 +130,11 @@ func getReflectFoldElem(c *foldContext, t reflect.Type) (reFoldFn, error) {
 }
 
 func foldInterfaceElem(C *foldContext, v reflect.Value) error {
-	if v.IsNil() {
+	if v.Kind() != reflect.Interface {
+		return foldAnyReflect(C, v)
+	}
+
+	if (v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface) && v.IsNil() {
 		return C.visitor.OnNil()
 	}
 	return foldAnyReflect(C, v.Elem())
@@ -220,7 +224,7 @@ func buildFieldFold(C *foldContext, t reflect.Type, idx int) (reFoldFn, error) {
 	}
 
 	if tagOpts.squash {
-		return buildFieldFoldInline(C, t, idx, tagOpts.omitEmpty)
+		return buildFieldFoldInline(C, t, idx)
 	}
 
 	foldT := st.Type
@@ -248,7 +252,6 @@ func buildFieldFoldInline(
 	C *foldContext,
 	t reflect.Type,
 	idx int,
-	omitEmpty bool,
 ) (reFoldFn, error) {
 	var (
 		st          = t.Field(idx)
@@ -284,7 +287,7 @@ func fieldFoldGenInline(C *foldContext, t reflect.Type) (reFoldFn, error) {
 		}
 	}
 
-	if t.Implements(tFolder) {
+	if implementsFolder(t) || implementsPtrFolder(t) {
 		return embeddObjReFold(C, reFoldFolderIfc), nil
 	}
 
@@ -316,7 +319,7 @@ func makeFieldInlineFold(idx int, fn reFoldFn) reFoldFn {
 }
 
 func makeNonEmptyFieldFold(name string, idx int, t reflect.Type, fn reFoldFn) (reFoldFn, error) {
-	resolver := makeResolveValue(t)
+	resolver := makeResolveNonEmptyValue(t)
 	if resolver == nil {
 		return makeFieldFold(name, idx, fn)
 	}
@@ -333,15 +336,42 @@ func makeNonEmptyFieldFold(name string, idx int, t reflect.Type, fn reFoldFn) (r
 	}, nil
 }
 
-func makeResolveValue(st reflect.Type) func(reflect.Value) (reflect.Value, bool) {
+func makeResolveNonEmptyValue(st reflect.Type) func(reflect.Value) (reflect.Value, bool) {
 	type resolver func(reflect.Value) (reflect.Value, bool)
 
 	resolveBySize := func(v reflect.Value) (reflect.Value, bool) {
 		return v, v.Len() > 0
 	}
 
-	resolveNonNil := func(v reflect.Value) (reflect.Value, bool) {
-		return v, !v.IsNil()
+	resolveEmptiable := func(v reflect.Value) (reflect.Value, bool) {
+		empty := v.Interface().(Emptiable).IsEmpty()
+		return v, !empty
+	}
+
+	resolveEmptiablePtr := func(v reflect.Value) (reflect.Value, bool) {
+		if v.CanAddr() {
+			return resolveEmptiable(v.Addr())
+		}
+
+		tmp := reflect.New(v.Type())
+		tmp.Elem().Set(v)
+		return resolveEmptiable(tmp)
+	}
+
+	resolveInterfaceLazy := func(v reflect.Value) (reflect.Value, bool) {
+		if v.IsNil() {
+			return v, false
+		}
+
+		// Find potential resolver based on interface element type.
+		// If no resolver is found, the value seems to be ok and should be reported.
+		elem := v.Elem()
+		resolver := makeResolveNonEmptyValue(elem.Type())
+		if resolver == nil {
+			return v, true // report, as v does not seem special
+		}
+
+		return resolver(v.Elem())
 	}
 
 	var resolvers []resolver
@@ -353,10 +383,15 @@ func makeResolveValue(st reflect.Type) func(reflect.Value) (reflect.Value, bool)
 			resolvers = append(resolvers, r)
 			continue
 		case reflect.Interface:
-			resolvers = append(resolvers, resolveNonNil)
+			resolvers = append(resolvers, resolveInterfaceLazy)
 		case reflect.Map, reflect.String, reflect.Slice, reflect.Array:
 			resolvers = append(resolvers, resolveBySize)
 		default:
+			if implementsEmptiable(st) {
+				resolvers = append(resolvers, resolveEmptiable)
+			} else if implementsPtrEmptiable(st) {
+				resolvers = append(resolvers, resolveEmptiablePtr)
+			}
 		}
 		break
 	}

--- a/gotype/fold_reflect.go
+++ b/gotype/fold_reflect.go
@@ -343,19 +343,19 @@ func makeResolveNonEmptyValue(st reflect.Type) func(reflect.Value) (reflect.Valu
 		return v, v.Len() > 0
 	}
 
-	resolveEmptiable := func(v reflect.Value) (reflect.Value, bool) {
+	resolveIsZeroer := func(v reflect.Value) (reflect.Value, bool) {
 		empty := v.Interface().(IsZeroer).IsZero()
 		return v, !empty
 	}
 
-	resolveEmptiablePtr := func(v reflect.Value) (reflect.Value, bool) {
+	resolveIsZeroerPtr := func(v reflect.Value) (reflect.Value, bool) {
 		if v.CanAddr() {
-			return resolveEmptiable(v.Addr())
+			return resolveIsZeroer(v.Addr())
 		}
 
 		tmp := reflect.New(v.Type())
 		tmp.Elem().Set(v)
-		return resolveEmptiable(tmp)
+		return resolveIsZeroer(tmp)
 	}
 
 	resolveInterfaceLazy := func(v reflect.Value) (reflect.Value, bool) {
@@ -388,9 +388,9 @@ func makeResolveNonEmptyValue(st reflect.Type) func(reflect.Value) (reflect.Valu
 			resolvers = append(resolvers, resolveBySize)
 		default:
 			if implementsIsZeroer(st) {
-				resolvers = append(resolvers, resolveEmptiable)
+				resolvers = append(resolvers, resolveIsZeroer)
 			} else if implementsPtrIsZeroer(st) {
-				resolvers = append(resolvers, resolveEmptiablePtr)
+				resolvers = append(resolvers, resolveIsZeroerPtr)
 			}
 		}
 		break

--- a/gotype/fold_test.go
+++ b/gotype/fold_test.go
@@ -42,7 +42,7 @@ type optInt struct {
 	value int
 }
 
-func (i optInt) IsEmpty() bool { return !i.set }
+func (i optInt) IsZero() bool { return !i.set }
 func (i optInt) Fold(v structform.ExtVisitor) error {
 	if i.set {
 		return v.OnInt(i.value)
@@ -55,7 +55,7 @@ type optIntPtr struct {
 	value int
 }
 
-func (i *optIntPtr) IsEmpty() bool { return i == nil || !i.set }
+func (i *optIntPtr) IsZero() bool { return i == nil || !i.set }
 func (i *optIntPtr) Fold(v structform.ExtVisitor) error {
 	if i != nil && i.set {
 		return v.OnInt(i.value)

--- a/gotype/fold_test.go
+++ b/gotype/fold_test.go
@@ -467,6 +467,13 @@ func foldSamples() map[string]foldCase {
 				B interface{} `struct:",omitempty"`
 			}{A: 1, B: &optIntPtr{}},
 		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B time.Time `struct:",omitempty"`
+			}{A: 1},
+		},
 
 		// omit empty with values
 		{

--- a/gotype/fold_test.go
+++ b/gotype/fold_test.go
@@ -37,6 +37,32 @@ type foldCase struct {
 	value interface{}
 }
 
+type optInt struct {
+	set   bool
+	value int
+}
+
+func (i optInt) IsEmpty() bool { return !i.set }
+func (i optInt) Fold(v structform.ExtVisitor) error {
+	if i.set {
+		return v.OnInt(i.value)
+	}
+	return v.OnNil()
+}
+
+type optIntPtr struct {
+	set   bool
+	value int
+}
+
+func (i *optIntPtr) IsEmpty() bool { return i == nil || !i.set }
+func (i *optIntPtr) Fold(v structform.ExtVisitor) error {
+	if i != nil && i.set {
+		return v.OnInt(i.value)
+	}
+	return v.OnNil()
+}
+
 func TestIter2JsonConsistent(t *testing.T) {
 	for name, test := range foldSamples() {
 		test := test
@@ -343,6 +369,104 @@ func foldSamples() map[string]foldCase {
 				B *struct{ C int } `struct:",omitempty"`
 			}{A: 1},
 		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B optInt `struct:",omitempty"`
+			}{A: 1},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B interface{} `struct:",omitempty"`
+			}{A: 1, B: optInt{}},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B *optInt `struct:",omitempty"`
+			}{A: 1},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B interface{} `struct:",omitempty"`
+			}{A: 1, B: (*optInt)(nil)},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B *optInt `struct:",omitempty"`
+			}{A: 1, B: &optInt{}},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B interface{} `struct:",omitempty"`
+			}{A: 1, B: optInt{}},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B interface{} `struct:",omitempty"`
+			}{A: 1, B: &optInt{}},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B optIntPtr `struct:",omitempty"`
+			}{A: 1},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B interface{} `struct:",omitempty"`
+			}{A: 1, B: optIntPtr{}},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B *optIntPtr `struct:",omitempty"`
+			}{A: 1},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B interface{} `struct:",omitempty"`
+			}{A: 1, B: (*optIntPtr)(nil)},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B *optIntPtr `struct:",omitempty"`
+			}{A: 1, B: &optIntPtr{}},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B interface{} `struct:",omitempty"`
+			}{A: 1, B: optIntPtr{}},
+		},
+		{
+			`{"a": 1}`,
+			struct {
+				A int
+				B interface{} `struct:",omitempty"`
+			}{A: 1, B: &optIntPtr{}},
+		},
 
 		// omit empty with values
 		{
@@ -386,6 +510,62 @@ func foldSamples() map[string]foldCase {
 				A int
 				B *struct{ C int } `struct:",omitempty"`
 			}{A: 1, B: &struct{ C int }{2}},
+		},
+		{
+			`{"a": 1, "b": 2}`,
+			struct {
+				A int
+				B optInt `struct:",omitempty"`
+			}{A: 1, B: optInt{set: true, value: 2}},
+		},
+		{
+			`{"a": 1, "b": 2}`,
+			struct {
+				A int
+				B *optInt `struct:",omitempty"`
+			}{A: 1, B: &optInt{set: true, value: 2}},
+		},
+		{
+			`{"a": 1, "b": 2}`,
+			struct {
+				A int
+				B interface{} `struct:",omitempty"`
+			}{A: 1, B: optInt{set: true, value: 2}},
+		},
+		{
+			`{"a": 1, "b": 2}`,
+			struct {
+				A int
+				B interface{} `struct:",omitempty"`
+			}{A: 1, B: &optInt{set: true, value: 2}},
+		},
+		{
+			`{"a": 1, "b": 2}`,
+			struct {
+				A int
+				B optIntPtr `struct:",omitempty"`
+			}{A: 1, B: optIntPtr{set: true, value: 2}},
+		},
+		{
+			`{"a": 1, "b": 2}`,
+			struct {
+				A int
+				B *optIntPtr `struct:",omitempty"`
+			}{A: 1, B: &optIntPtr{set: true, value: 2}},
+		},
+		{
+			`{"a": 1, "b": 2}`,
+			struct {
+				A int
+				B interface{} `struct:",omitempty"`
+			}{A: 1, B: optIntPtr{set: true, value: 2}},
+		},
+		{
+			`{"a": 1, "b": 2}`,
+			struct {
+				A int
+				B interface{} `struct:",omitempty"`
+			}{A: 1, B: &optIntPtr{set: true, value: 2}},
 		},
 
 		// omit

--- a/gotype/tags.go
+++ b/gotype/tags.go
@@ -19,6 +19,18 @@ package gotype
 
 import "strings"
 
+// tagOptions represents additional per field options that have
+// been parsed from the struct tags.
+//
+// Available options are:
+//   - squash, inline: The field must be a map[string]... or another struct.
+//     All fields from the struct will be treated like they belong to the current
+//     struct.
+//   - omit: The field is never reported
+//   - omitempty: The field is not reported if the value is assumed to be empty.
+//     Strings, arrays, maps of 0 length and nil pointers are always assumed to be empty.
+//     Custom types can implement the `IsZero() bool` method (IsZeroer interface). If the
+//     `IsZero` method is true and `omitempty` has been set, the field will be ignored.
 type tagOptions struct {
 	squash    bool
 	omitEmpty bool


### PR DESCRIPTION
Adds new interface type `IsZeroer`, that can be used for custom types that shall omitted if they are assumed to be empty.

For example the `OptInt` type implements `IsZero`:

```
type OptInt {
  set bool
  value int
}

func (i OptInt) IsZero() bool { return !i.set }
```

a struct like this:

```

type T struct {
  A int
  B OptInt `struct:",omitempty"`
}
```

will always report the key value pair `A: <value>`, but `B` will only be reported if `OptInt.Empty()` return false.

The change ensures that `IsZero()` can be implemented on the value, or the pointer type like `func (i OptInt) IsZero() bool` or `func (i *OptInt) IsZero() bool`.

Caveat: If `IsZero()` is implemented on the pointer type, but the type (or parent structure) is not given as a pointer type to `Fold`, then a temporary value must be allocated, in order to call `IsZero` properly. The extra allocation is not required if the type is received by value, but the runtime might allocate and copy values in that case.



The `Folder` interface now can be  implemented on the Value or pointer type as well. Confusion on the type, sometimes did lead to `Fold` not being executed, depending on how the value was passed.