### PR TITLE
json: avoid endless loop on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Fix to break out of endless loop. (PR #36)
 
 ## [0.0.9]
 

--- a/json/parse.go
+++ b/json/parse.go
@@ -241,6 +241,10 @@ func (p *Parser) feedUntil(b []byte) (int, bool, error) {
 			return 0, false, errFailing
 		}
 
+		if err != nil {
+			break
+		}
+
 		reported = reported && len(p.states) == 0
 	}
 


### PR DESCRIPTION
Signed-off-by: Florian Lehner <florian.lehner@elastic.co>

`feedUntil()` can end up in a endless loop if the `b` is not modified by the `stateXX` function and instead an error is returned. In such a case it would be best to return from the for-loop.

Simple example to reproduce this issue:
```
	unfolder, _ := gotype.NewUnfolder(nil)
	jsonParser := NewParser(unfolder)
	jsonParser.ParseString(`{"hello": "world"}`)	
```