### PR TITLE
reorder structs for better memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Reorder elements in structs to reduce memory. (PR #37)
 
 ### Deprecated
 

--- a/cborl/decode.go
+++ b/cborl/decode.go
@@ -24,11 +24,11 @@ import (
 )
 
 type Decoder struct {
-	p Parser
-
+	in      io.Reader
 	buffer  []byte
 	buffer0 []byte
-	in      io.Reader
+
+	p Parser
 }
 
 func NewDecoder(in io.Reader, buffer int, vs structform.Visitor) *Decoder {

--- a/cborl/parse.go
+++ b/cborl/parse.go
@@ -32,12 +32,12 @@ type Parser struct {
 	// last fail state
 	err error
 
+	buffer []byte
+
 	// parser state machine
 	state stateStack
 
-	length lengthStack
-
-	buffer  []byte
+	length  lengthStack
 	buffer0 [64]byte
 }
 

--- a/cborl/visitor.go
+++ b/cborl/visitor.go
@@ -27,9 +27,8 @@ import (
 
 type Visitor struct {
 	w       writer
+	length  lengthStack
 	scratch [16]byte
-
-	length lengthStack
 }
 
 type writer struct {

--- a/gotype/unfold.go
+++ b/gotype/unfold.go
@@ -29,23 +29,21 @@ type Unfolder struct {
 }
 
 type unfoldCtx struct {
-	opts options
-
-	// buf buffer
+	unfolder unfolderStack
+	ptr      ptrStack
 
 	userReg map[reflect.Type]reflUnfolder
 	reg     *typeUnfoldRegistry
 
-	unfolder unfolderStack
-	value    reflectValueStack
-	baseType structformTypeStack
-	ptr      ptrStack
-	key      keyStack
-	idx      idxStack
+	value reflectValueStack
+	key   keyStack
 
-	keyCache symbolCache
-
+	keyCache    symbolCache
+	opts        options
 	valueBuffer unfoldBuf
+
+	baseType structformTypeStack
+	idx      idxStack
 }
 
 type unfoldBuf struct {

--- a/json/decode.go
+++ b/json/decode.go
@@ -24,11 +24,10 @@ import (
 )
 
 type Decoder struct {
-	p Parser
-
+	in      io.Reader
 	buffer  []byte
 	buffer0 []byte
-	in      io.Reader
+	p       Parser
 }
 
 func NewDecoder(in io.Reader, buffer int, vs structform.Visitor) *Decoder {

--- a/json/visitor.go
+++ b/json/visitor.go
@@ -32,12 +32,13 @@ import (
 type Visitor struct {
 	w writer
 
-	scratch [64]byte
+	escapeSet []bool
 
 	first   boolStack
 	inArray boolStack
 
-	escapeSet          []bool
+	scratch [64]byte
+
 	ignoreInvalidFloat bool
 }
 

--- a/ubjson/decode.go
+++ b/ubjson/decode.go
@@ -24,11 +24,10 @@ import (
 )
 
 type Decoder struct {
-	p Parser
-
+	in      io.Reader
 	buffer  []byte
 	buffer0 []byte
-	in      io.Reader
+	p       Parser
 }
 
 func NewDecoder(in io.Reader, buffer int, vs structform.Visitor) *Decoder {

--- a/ubjson/parse.go
+++ b/ubjson/parse.go
@@ -31,7 +31,8 @@ type Parser struct {
 	strVisitor structform.StringRefVisitor
 
 	// last fail state
-	err error
+	err    error
+	buffer []byte
 
 	// parser state machine
 	state      stateStack
@@ -39,7 +40,6 @@ type Parser struct {
 
 	length lengthStack
 
-	buffer  []byte
 	buffer0 [64]byte
 
 	// internal parser state

--- a/ubjson/visitor.go
+++ b/ubjson/visitor.go
@@ -28,9 +28,8 @@ import (
 
 type Visitor struct {
 	w       writer
+	length  lengthStack
 	scratch [16]byte
-
-	length lengthStack
 }
 
 type writer struct {


### PR DESCRIPTION
Signed-off-by: Florian Lehner <florian.lehner@elastic.co>

Reorder structs to reduce required memory.