### PR TITLE
Reduce memory footprint of structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Remove duplicate fields to avoid unnecessary struct grows. (PR #38)
 
 ### Deprecated
 

--- a/json/decode.go
+++ b/json/decode.go
@@ -26,15 +26,14 @@ import (
 type Decoder struct {
 	p Parser
 
-	buffer  []byte
-	buffer0 []byte
-	in      io.Reader
+	buffer []byte
+	in     io.Reader
 }
 
 func NewDecoder(in io.Reader, buffer int, vs structform.Visitor) *Decoder {
 	dec := &Decoder{
-		buffer0: make([]byte, buffer),
-		in:      in,
+		buffer: make([]byte, 0, buffer),
+		in:     in,
 	}
 	dec.p.init(vs)
 	return dec
@@ -42,9 +41,8 @@ func NewDecoder(in io.Reader, buffer int, vs structform.Visitor) *Decoder {
 
 func NewBytesDecoder(b []byte, vs structform.Visitor) *Decoder {
 	dec := &Decoder{
-		buffer:  b,
-		buffer0: b[:0],
-		in:      nil,
+		buffer: b,
+		in:     nil,
 	}
 	dec.p.init(vs)
 	return dec
@@ -66,8 +64,8 @@ func (dec *Decoder) Next() error {
 				return io.EOF
 			}
 
-			n, err := dec.in.Read(dec.buffer0)
-			dec.buffer = dec.buffer0[:n]
+			n, err := dec.in.Read(dec.buffer)
+			dec.buffer = dec.buffer[:n]
 			if n == 0 && err != nil {
 				return err
 			}

--- a/json/parse.go
+++ b/json/parse.go
@@ -45,7 +45,8 @@ type Parser struct {
 	// preallocate stack memory for up to 32 nested arrays/objects
 	statesBuf [32]state
 
-	literalBuffer  []byte
+	literalBuffer []byte
+	// literalBuffer0 is used as a fast reset option for literalBuffer without allocation.
 	literalBuffer0 [64]byte
 
 	inEscape bool

--- a/json/visitor.go
+++ b/json/visitor.go
@@ -43,7 +43,6 @@ type Visitor struct {
 
 type boolStack struct {
 	stack   []bool
-	stack0  [32]bool
 	current bool
 }
 
@@ -433,7 +432,7 @@ func (vs *Visitor) onFloat(f float64, bits int) error {
 }
 
 func (s *boolStack) init() {
-	s.stack = s.stack0[:0]
+	s.stack = make([]bool, 0, 32)
 }
 
 func (s *boolStack) push(b bool) {


### PR DESCRIPTION
Remove duplicate fields to avoid unnecessary struct grows. 