### PR TITLE
fix: register reFoldFn for types that derive from primitives

### DIFF
--- a/gotype/fold.go
+++ b/gotype/fold.go
@@ -72,6 +72,7 @@ func NewIterator(vs structform.Visitor, opts ...FoldOption) (*Iterator, error) {
 		userReg = map[reflect.Type]reFoldFn{}
 		for typ, folder := range O.foldFns {
 			reg.set(typ, folder)
+			userReg[typ] = folder
 		}
 	}
 


### PR DESCRIPTION
This PR fixes the encoding of types that derive from a primitive type, such as net.IP which derives from []byte. I added a unit-test to capture that

before this fix [ci run](https://buildkite.com/elastic/go-structform/builds/9)
after this fix [ci run](https://buildkite.com/elastic/go-structform/builds/10)

Relates https://github.com/elastic/beats/issues/37764