### PR TITLE
Add SetExplicitRadixPoint config to json.Visitor

### DIFF
--- a/json/json_test.go
+++ b/json/json_test.go
@@ -172,7 +172,7 @@ func TestEncodeIgnoreSpecialFloatValues(t *testing.T) {
 	}
 }
 
-func TestEncodeUnambiguousFloat(t *testing.T) {
+func TestEncodeExplicitRadixPoint(t *testing.T) {
 	cases := map[string]struct {
 		tokens sftest.Recording
 		want   string
@@ -207,7 +207,7 @@ func TestEncodeUnambiguousFloat(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var buf strings.Builder
 			visitor := NewVisitor(&buf)
-			visitor.SetUnambiguousFloat(true)
+			visitor.SetExplicitRadixPoint(true)
 
 			err := test.tokens.Replay(visitor)
 			require.NoError(t, err)

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -171,3 +171,48 @@ func TestEncodeIgnoreSpecialFloatValues(t *testing.T) {
 		})
 	}
 }
+
+func TestEncodeUnambiguousFloat(t *testing.T) {
+	cases := map[string]struct {
+		tokens sftest.Recording
+		want   string
+	}{
+		"1e+10": {
+			tokens: sftest.Recording{
+				sftest.Float64Rec{1e+10},
+			},
+			want: `1.0e+10`,
+		},
+		"1.1e+10": {
+			tokens: sftest.Recording{
+				sftest.Float64Rec{1.1e+10},
+			},
+			want: `1.1e+10`,
+		},
+		"1": {
+			tokens: sftest.Recording{
+				sftest.Float64Rec{1},
+			},
+			want: `1.0`,
+		},
+		"1.1": {
+			tokens: sftest.Recording{
+				sftest.Float64Rec{1.1},
+			},
+			want: `1.1`,
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			var buf strings.Builder
+			visitor := NewVisitor(&buf)
+			visitor.SetUnambiguousFloat(true)
+
+			err := test.tokens.Replay(visitor)
+			require.NoError(t, err)
+
+			require.Equal(t, test.want, buf.String())
+		})
+	}
+}


### PR DESCRIPTION
SetExplicitRadixPoint configures whether the visitor encodes floating point values with an explicit radix point.
By default, equiv to SetExplicitRadixPoint(false), the radix point will be skipped if it is not needed.
e.g. 1.0 to 1 instead of 1.0, 100000000 to 1e+8 instead of 1.0e+8.
If true is passed, the encoded number will always contain a radix point,
in either decimal form or scientific notation.
This may be useful to signal the type of the number to a json parser.

Related issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34680